### PR TITLE
Acp bench aggregations

### DIFF
--- a/lm_eval/tasks/acpbench/boolq_cot_2shot/_boolq_cot_2shot_yaml
+++ b/lm_eval/tasks/acpbench/boolq_cot_2shot/_boolq_cot_2shot_yaml
@@ -1,6 +1,5 @@
 tag:
   - acp_bool_cot_2shot
-  - acp_bench
 output_type: generate_until
 dataset_path: ibm-research/acp_bench
 test_split: test

--- a/lm_eval/tasks/acpbench/mcq_cot_2shot/_mcq_cot_2shot_yaml
+++ b/lm_eval/tasks/acpbench/mcq_cot_2shot/_mcq_cot_2shot_yaml
@@ -1,6 +1,5 @@
 tag:
   - acp_mcq_cot_2shot
-  - acp_bench
 output_type: generate_until
 dataset_path: ibm-research/acp_bench
 test_split: test

--- a/lm_eval/tasks/acpbench/task_groups/_acp_bench.yaml
+++ b/lm_eval/tasks/acpbench/task_groups/_acp_bench.yaml
@@ -6,6 +6,6 @@ aggregate_metric_list:
   - metric: exact_match
     aggregation: mean
     weight_by_size: true
-    filter_list: "extract-yes-no"
+    filter_list: ["extract-yes-no", "mcq-extract"]
 metadata:
   version: 1

--- a/lm_eval/tasks/acpbench/task_groups/_acp_bench.yaml
+++ b/lm_eval/tasks/acpbench/task_groups/_acp_bench.yaml
@@ -1,0 +1,11 @@
+group: acp_bench
+task:
+  - acp_bench_bool
+  - acp_bench_mcq
+aggregate_metric_list:
+  - metric: exact_match
+    aggregation: mean
+    weight_by_size: true
+    filter_list: "extract-yes-no"
+metadata:
+  version: 1

--- a/lm_eval/tasks/acpbench/task_groups/_acp_bench_bool.yaml
+++ b/lm_eval/tasks/acpbench/task_groups/_acp_bench_bool.yaml
@@ -1,0 +1,16 @@
+group: acp_bench_bool
+task:
+  - acp_areach_bool
+  - acp_app_bool
+  - acp_just_bool
+  - acp_land_bool
+  - acp_prog_bool
+  - acp_reach_bool
+  - acp_val_bool
+aggregate_metric_list:
+  - metric: exact_match
+    aggregation: mean
+    weight_by_size: true
+    filter_list: "extract-yes-no"
+metadata:
+  version: 1

--- a/lm_eval/tasks/acpbench/task_groups/_acp_bench_mcq.yaml
+++ b/lm_eval/tasks/acpbench/task_groups/_acp_bench_mcq.yaml
@@ -11,6 +11,6 @@ aggregate_metric_list:
   - metric: exact_match
     aggregation: mean
     weight_by_size: true
-    filter_list: "extract-yes-no"
+    filter_list: "mcq-extract"
 metadata:
   version: 1

--- a/lm_eval/tasks/acpbench/task_groups/_acp_bench_mcq.yaml
+++ b/lm_eval/tasks/acpbench/task_groups/_acp_bench_mcq.yaml
@@ -1,0 +1,16 @@
+group: acp_bench_mcq
+task:
+  - acp_areach_mcq
+  - acp_app_mcq
+  - acp_just_mcq
+  - acp_land_mcq
+  - acp_prog_mcq
+  - acp_reach_mcq
+  - acp_val_mcq
+aggregate_metric_list:
+  - metric: exact_match
+    aggregation: mean
+    weight_by_size: true
+    filter_list: "extract-yes-no"
+metadata:
+  version: 1


### PR DESCRIPTION
Using task groups instead of tags for ACP bench to get aggregated metrics