### PR TITLE
Fix gemma code indentation issue

### DIFF
--- a/lm_eval/tasks/humaneval/utils.py
+++ b/lm_eval/tasks/humaneval/utils.py
@@ -1,5 +1,5 @@
 import evaluate as hf_evaluate
-
+import re
 
 try:
     compute_ = hf_evaluate.load("code_eval")
@@ -24,15 +24,17 @@ def pass_at_k(references: list[str], predictions: list[list[str]], k: list[int] 
 
 
 def build_predictions(resps: list[list[str]], docs: list[dict]) -> list[list[str]]:
-    return [[doc["prompt"] + r.replace("```python\n", "") for r in resp] for resp, doc in zip(resps, docs)]
+    return [[doc["prompt"] + clean_text(r.replace("```python\n", "")) for r in resp] for resp, doc in zip(resps, docs)]
 
+def clean_text(text: str) -> str:
+    return re.sub(r'\n(▁+)', lambda m: '\n' + ' ' * len(m.group(1)), text)
 
 def build_predictions_instruct(
     resps: list[list[str]], docs: list[dict]
 ) -> list[list[str]]:
     return [
         [
-            doc["prompt"] + (r if r.find("```") == -1 else r[: r.find("```")])
+            doc["prompt"] + (clean_text(r) if r.find("```") == -1 else clean_text(r[: r.find("```")]))
             for r in resp
         ]
         for resp, doc in zip(resps, docs)

--- a/lm_eval/tasks/mbpp/utils.py
+++ b/lm_eval/tasks/mbpp/utils.py
@@ -29,6 +29,9 @@ def pass_at_1(
     )[0]["pass@1"]
 
 
+def clean_text(text: str) -> str:
+    return re.sub(r'\n(▁+)', lambda m: '\n' + ' ' * len(m.group(1)), text)
+
 def extract_code_blocks(text: str) -> str:
     # Pattern to match ```...``` blocks
     pattern = r"```(?:\w+)?\n?(.*?)\n?```"
@@ -41,7 +44,7 @@ def extract_code_blocks(text: str) -> str:
     if not matches:
         return ""
     else:
-        return matches[0]
+        return clean_text(matches[0])
 
 
 def build_predictions(resps: list[list[str]], docs: list[dict]) -> list[list[str]]:


### PR DESCRIPTION
This PR fixes Gemma issue when evaluated on MBPP and HumanEval benchmarks. Gemma models for some reason use underscores for indentation instead of spaces as in below:
`'```python\ndef remove_Occ(s, c):\n▁▁"""\n▁▁Removes the first and last occurrence of a given character from the string.\n\n▁▁Args:\n▁▁▁▁s: The input string.\n▁▁▁▁c: The character to remove.\n\n▁▁Returns:\n▁▁▁▁The string with the first and last occurrence of the character removed.\n▁▁"""\n▁▁first_index = -1\n▁▁last_index = -1\n\n▁▁for i in range(len(s)):\n▁▁▁▁if s[i] == c:\n▁▁▁▁▁▁if first_index == -1:\n▁▁▁▁▁▁▁▁first_index = i\n▁▁▁▁▁▁last_index = i\n\n▁▁if first_index == -1:\n▁▁▁▁return s\n\n▁▁new_string = s[:first_index] + s[first_index+1:last_index] + s[last_index+1:]\n▁▁return new_string\n```' `