### PR TITLE
Drop benchmark fix for instruct models

### DIFF
--- a/lm_eval/tasks/drop/default.yaml
+++ b/lm_eval/tasks/drop/default.yaml
@@ -7,20 +7,24 @@ fewshot_split: train
 test_split: validation
 num_fewshot: 3
 process_docs: !function utils.process_docs
-doc_to_text: "Passage: {{passage}}\nQuestion: {{question}}\nAnswer: "
+doc_to_text: "Passage: {{passage}}\nQuestion: {{question}}"
 doc_to_target: !function utils.doc_to_target
 target_delimiter: ""
 process_results: !function utils.process_results
 should_decontaminate: true
-doc_to_decontamination_query: "Passage: {{passage}}\nQuestion: {{question}}\nAnswer: "
+doc_to_decontamination_query: "Passage: {{passage}}\nQuestion: {{question}}"
+gen_prefix: "Answer: "
+description: "Return only the answer. No explanation."
 generation_kwargs:
   until:
     - "Passage:"
     - "Question:"
+    - "\n\n"
     - </s>
     - <|im_end|>
     - <|endoftext|>
     - <|eot_id|>
+  do_sample: false
 metric_list:
   - metric: em
     aggregation: mean


### PR DESCRIPTION
fix the drop benchmark for the instruct models while maintaining compatibility with the base model.
The main issue was with verbosity in the chat template but the additional system prompt resolved the issue.
Additionally the "Answer:" prefix remained in the user prompt. It was moved as a prefix for the assistant's completion