### PR TITLE
Bbh fix

### DIFF
--- a/lm_eval/tasks/bbh/cot_fewshot/_cot_fewshot_template_yaml
+++ b/lm_eval/tasks/bbh/cot_fewshot/_cot_fewshot_template_yaml
@@ -14,7 +14,7 @@ generation_kwargs:
   until:
     - "</s>"
     - "Q"
-    - "\n\n"
+#     - "\n\n"
   do_sample: false
   temperature: 0.0
 filter_list:

--- a/lm_eval/tasks/bbh/cot_fewshot/boolean_expressions.yaml
+++ b/lm_eval/tasks/bbh/cot_fewshot/boolean_expressions.yaml
@@ -1,6 +1,7 @@
 dataset_name: "boolean_expressions"
 description: "Evaluate the result of a random Boolean expression.\n\n"
-doc_to_text: "Q: {{input}}\nA: Let's think step by step.\n"
+doc_to_text: "Q: {{input}}\n"
+gen_prefix: "A: Let's think step by step.\n"
 include: "_cot_fewshot_template_yaml"
 task: "bbh_cot_fewshot_boolean_expressions"
 fewshot_config:

--- a/lm_eval/tasks/bbh/cot_fewshot/causal_judgement.yaml
+++ b/lm_eval/tasks/bbh/cot_fewshot/causal_judgement.yaml
@@ -1,13 +1,7 @@
 dataset_name: causal_judgement
-description: 'Answer questions about causal attribution.
-
-
-  '
-doc_to_text: 'Q: {{input}}
-
-  A: Let''s think step by step.
-
-  '
+description: "Answer questions about causal attribution.\n\n"
+doc_to_text: "Q: {{input}}\n"
+gen_prefix: "A: Let's think step by step.\n"
 fewshot_config:
   sampler: first_n
   samples:

--- a/lm_eval/tasks/bbh/cot_fewshot/date_understanding.yaml
+++ b/lm_eval/tasks/bbh/cot_fewshot/date_understanding.yaml
@@ -1,13 +1,7 @@
 dataset_name: date_understanding
-description: 'Infer the date from context.
-
-
-  '
-doc_to_text: 'Q: {{input}}
-
-  A: Let''s think step by step.
-
-  '
+description: "Infer the date from context.\n\n"
+doc_to_text: "Q: {{input}}\n"
+gen_prefix: "A: Let's think step by step.\n"
 fewshot_config:
   sampler: first_n
   samples:

--- a/lm_eval/tasks/bbh/cot_fewshot/disambiguation_qa.yaml
+++ b/lm_eval/tasks/bbh/cot_fewshot/disambiguation_qa.yaml
@@ -1,13 +1,7 @@
 dataset_name: disambiguation_qa
-description: 'Clarify the meaning of sentences with ambiguous pronouns.
-
-
-  '
-doc_to_text: 'Q: {{input}}
-
-  A: Let''s think step by step.
-
-  '
+description: "Clarify the meaning of sentences with ambiguous pronouns.\n\n"
+doc_to_text: "Q: {{input}}\n"
+gen_prefix: "A: Let's think step by step.\n"
 fewshot_config:
   sampler: first_n
   samples:

--- a/lm_eval/tasks/bbh/cot_fewshot/dyck_languages.yaml
+++ b/lm_eval/tasks/bbh/cot_fewshot/dyck_languages.yaml
@@ -1,13 +1,7 @@
 dataset_name: dyck_languages
-description: 'Correctly close a Dyck-n word.
-
-
-  '
-doc_to_text: 'Q: {{input}}
-
-  A: Let''s think step by step.
-
-  '
+description: "Correctly close a Dyck-n word.\n\n"
+doc_to_text: "Q: {{input}}\n"
+gen_prefix: "A: Let's think step by step.\n"
 fewshot_config:
   sampler: first_n
   samples:

--- a/lm_eval/tasks/bbh/cot_fewshot/formal_fallacies.yaml
+++ b/lm_eval/tasks/bbh/cot_fewshot/formal_fallacies.yaml
@@ -1,13 +1,7 @@
 dataset_name: formal_fallacies
-description: 'Distinguish deductively valid arguments from formal fallacies.
-
-
-  '
-doc_to_text: 'Q: {{input}}
-
-  A: Let''s think step by step.
-
-  '
+description: "Distinguish deductively valid arguments from formal fallacies.\n\n"
+doc_to_text: "Q: {{input}}\n"
+gen_prefix: "A: Let's think step by step.\n"
 fewshot_config:
   sampler: first_n
   samples:

--- a/lm_eval/tasks/bbh/cot_fewshot/geometric_shapes.yaml
+++ b/lm_eval/tasks/bbh/cot_fewshot/geometric_shapes.yaml
@@ -1,13 +1,7 @@
 dataset_name: geometric_shapes
-description: 'Name geometric shapes from their SVG paths.
-
-
-  '
-doc_to_text: 'Q: {{input}}
-
-  A: Let''s think step by step.
-
-  '
+description: "Name geometric shapes from their SVG paths.\n\n"
+doc_to_text: "Q: {{input}}\n"
+gen_prefix: "A: Let's think step by step.\n"
 fewshot_config:
   sampler: first_n
   samples:

--- a/lm_eval/tasks/bbh/cot_fewshot/hyperbaton.yaml
+++ b/lm_eval/tasks/bbh/cot_fewshot/hyperbaton.yaml
@@ -1,13 +1,7 @@
 dataset_name: hyperbaton
-description: 'Order adjectives correctly in English sentences.
-
-
-  '
-doc_to_text: 'Q: {{input}}
-
-  A: Let''s think step by step.
-
-  '
+description: "Order adjectives correctly in English sentences.\n\n"
+doc_to_text: "Q: {{input}}\n"
+gen_prefix: "A: Let's think step by step.\n"
 fewshot_config:
   sampler: first_n
   samples:

--- a/lm_eval/tasks/bbh/cot_fewshot/logical_deduction_five_objects.yaml
+++ b/lm_eval/tasks/bbh/cot_fewshot/logical_deduction_five_objects.yaml
@@ -1,14 +1,7 @@
 dataset_name: logical_deduction_five_objects
-description: 'A logical deduction task which requires deducing the order of a sequence
-  of objects.
-
-
-  '
-doc_to_text: 'Q: {{input}}
-
-  A: Let''s think step by step.
-
-  '
+description: "A logical deduction task which requires deducing the order of a sequence of objects.\n\n"
+doc_to_text: "Q: {{input}}\n"
+gen_prefix: "A: Let's think step by step.\n"
 fewshot_config:
   sampler: first_n
   samples:

--- a/lm_eval/tasks/bbh/cot_fewshot/logical_deduction_seven_objects.yaml
+++ b/lm_eval/tasks/bbh/cot_fewshot/logical_deduction_seven_objects.yaml
@@ -1,14 +1,7 @@
 dataset_name: logical_deduction_seven_objects
-description: 'A logical deduction task which requires deducing the order of a sequence
-  of objects.
-
-
-  '
-doc_to_text: 'Q: {{input}}
-
-  A: Let''s think step by step.
-
-  '
+description: "A logical deduction task which requires deducing the order of a sequence of objects.\n\n"
+doc_to_text: "Q: {{input}}\n"
+gen_prefix: "A: Let's think step by step.\n"
 fewshot_config:
   sampler: first_n
   samples:

--- a/lm_eval/tasks/bbh/cot_fewshot/logical_deduction_three_objects.yaml
+++ b/lm_eval/tasks/bbh/cot_fewshot/logical_deduction_three_objects.yaml
@@ -1,14 +1,7 @@
 dataset_name: logical_deduction_three_objects
-description: 'A logical deduction task which requires deducing the order of a sequence
-  of objects.
-
-
-  '
-doc_to_text: 'Q: {{input}}
-
-  A: Let''s think step by step.
-
-  '
+description: "A logical deduction task which requires deducing the order of a sequence of objects.\n\n"
+doc_to_text: "Q: {{input}}\n"
+gen_prefix: "A: Let's think step by step.\n"
 fewshot_config:
   sampler: first_n
   samples:

--- a/lm_eval/tasks/bbh/cot_fewshot/movie_recommendation.yaml
+++ b/lm_eval/tasks/bbh/cot_fewshot/movie_recommendation.yaml
@@ -1,13 +1,7 @@
 dataset_name: movie_recommendation
-description: 'Recommend movies similar to the given list of movies.
-
-
-  '
-doc_to_text: 'Q: {{input}}
-
-  A: Let''s think step by step.
-
-  '
+description: "Recommend movies similar to the given list of movies.\n\n"
+doc_to_text: "Q: {{input}}\n"
+gen_prefix: "A: Let's think step by step.\n"
 fewshot_config:
   sampler: first_n
   samples:

--- a/lm_eval/tasks/bbh/cot_fewshot/multistep_arithmetic_two.yaml
+++ b/lm_eval/tasks/bbh/cot_fewshot/multistep_arithmetic_two.yaml
@@ -1,13 +1,7 @@
 dataset_name: multistep_arithmetic_two
-description: 'Solve multi-step arithmetic problems.
-
-
-  '
-doc_to_text: 'Q: {{input}}
-
-  A: Let''s think step by step.
-
-  '
+description: "Solve multi-step arithmetic problems.\n\n"
+doc_to_text: "Q: {{input}}\n"
+gen_prefix: "A: Let's think step by step.\n"
 fewshot_config:
   sampler: first_n
   samples:

--- a/lm_eval/tasks/bbh/cot_fewshot/navigate.yaml
+++ b/lm_eval/tasks/bbh/cot_fewshot/navigate.yaml
@@ -1,14 +1,7 @@
 dataset_name: navigate
-description: 'Given a series of navigation instructions, determine whether one would
-  end up back at the starting point.
-
-
-  '
-doc_to_text: 'Q: {{input}}
-
-  A: Let''s think step by step.
-
-  '
+description: "Given a series of navigation instructions, determine whether one would end up back at the starting point.\n\n"
+doc_to_text: "Q: {{input}}\n"
+gen_prefix: "A: Let's think step by step.\n"
 fewshot_config:
   sampler: first_n
   samples:

--- a/lm_eval/tasks/bbh/cot_fewshot/object_counting.yaml
+++ b/lm_eval/tasks/bbh/cot_fewshot/object_counting.yaml
@@ -1,14 +1,7 @@
 dataset_name: object_counting
-description: 'Questions that involve enumerating objects and asking the model to count
-  them.
-
-
-  '
-doc_to_text: 'Q: {{input}}
-
-  A: Let''s think step by step.
-
-  '
+description: "Questions that involve enumerating objects and asking the model to count them.\n\n"
+doc_to_text: "Q: {{input}}\n"
+gen_prefix: "A: Let's think step by step.\n"
 fewshot_config:
   sampler: first_n
   samples:

--- a/lm_eval/tasks/bbh/cot_fewshot/penguins_in_a_table.yaml
+++ b/lm_eval/tasks/bbh/cot_fewshot/penguins_in_a_table.yaml
@@ -1,13 +1,7 @@
 dataset_name: penguins_in_a_table
-description: 'Answer questions about a table of penguins and their attributes.
-
-
-  '
-doc_to_text: 'Q: {{input}}
-
-  A: Let''s think step by step.
-
-  '
+description: "Answer questions about a table of penguins and their attributes.\n\n"
+doc_to_text: "Q: {{input}}\n"
+gen_prefix: "A: Let's think step by step.\n"
 fewshot_config:
   sampler: first_n
   samples:

--- a/lm_eval/tasks/bbh/cot_fewshot/reasoning_about_colored_objects.yaml
+++ b/lm_eval/tasks/bbh/cot_fewshot/reasoning_about_colored_objects.yaml
@@ -1,13 +1,7 @@
 dataset_name: reasoning_about_colored_objects
-description: 'Answer extremely simple questions about the colors of objects on a surface.
-
-
-  '
-doc_to_text: 'Q: {{input}}
-
-  A: Let''s think step by step.
-
-  '
+description: "Answer extremely simple questions about the colors of objects on a surface.\n\n"
+doc_to_text: "Q: {{input}}\n"
+gen_prefix: "A: Let's think step by step.\n"
 fewshot_config:
   sampler: first_n
   samples:

--- a/lm_eval/tasks/bbh/cot_fewshot/ruin_names.yaml
+++ b/lm_eval/tasks/bbh/cot_fewshot/ruin_names.yaml
@@ -1,14 +1,7 @@
 dataset_name: ruin_names
-description: 'Select the humorous edit that ''ruins'' the input movie or musical artist
-  name.
-
-
-  '
-doc_to_text: 'Q: {{input}}
-
-  A: Let''s think step by step.
-
-  '
+description: "Select the humorous edit that ''ruins'' the input movie or musical artist name.\n\n"
+doc_to_text: "Q: {{input}}\n"
+gen_prefix: "A: Let's think step by step.\n"
 fewshot_config:
   sampler: first_n
   samples:

--- a/lm_eval/tasks/bbh/cot_fewshot/salient_translation_error_detection.yaml
+++ b/lm_eval/tasks/bbh/cot_fewshot/salient_translation_error_detection.yaml
@@ -1,14 +1,7 @@
 dataset_name: salient_translation_error_detection
-description: 'Detect the type of error in an English translation of a German source
-  sentence.
-
-
-  '
-doc_to_text: 'Q: {{input}}
-
-  A: Let''s think step by step.
-
-  '
+description: "Detect the type of error in an English translation of a German source sentence.\n\n"
+doc_to_text: "Q: {{input}}\n"
+gen_prefix: "A: Let's think step by step.\n"
 fewshot_config:
   sampler: first_n
   samples:

--- a/lm_eval/tasks/bbh/cot_fewshot/snarks.yaml
+++ b/lm_eval/tasks/bbh/cot_fewshot/snarks.yaml
@@ -1,19 +1,11 @@
 dataset_name: snarks
-description: 'Determine which of two sentences is sarcastic.
-
-
-  According to Cambridge University Dictionary, sarcasm is "the use of remarks that
+description: "Determine which of two sentences is sarcastic.\n\n
+  According to Cambridge University Dictionary, sarcasm is ''the use of remarks that
   clearly mean the opposite of what they say, made in order to hurt someone''s feelings
-  or to criticize something in a humorous way." Sarcastic sentences often contain
-  satirical or ironic utterances, hyperboles, ambivalent or witty remarks.
-
-
-  '
-doc_to_text: 'Q: {{input}}
-
-  A: Let''s think step by step.
-
-  '
+  or to criticize something in a humorous way.'' Sarcastic sentences often contain
+  satirical or ironic utterances, hyperboles, ambivalent or witty remarks.\n\n"
+doc_to_text: "Q: {{input}}\n"
+gen_prefix: "A: Let's think step by step.\n"
 fewshot_config:
   sampler: first_n
   samples:

--- a/lm_eval/tasks/bbh/cot_fewshot/sports_understanding.yaml
+++ b/lm_eval/tasks/bbh/cot_fewshot/sports_understanding.yaml
@@ -1,14 +1,7 @@
 dataset_name: sports_understanding
-description: 'Determine whether an artificially constructed sentence relating to sports
-  is plausible or not.
-
-
-  '
-doc_to_text: 'Q: {{input}}
-
-  A: Let''s think step by step.
-
-  '
+description: "Determine whether an artificially constructed sentence relating to sports is plausible or not.\n\n"
+doc_to_text: "Q: {{input}}\n"
+gen_prefix: "A: Let's think step by step.\n"
 fewshot_config:
   sampler: first_n
   samples:

--- a/lm_eval/tasks/bbh/cot_fewshot/temporal_sequences.yaml
+++ b/lm_eval/tasks/bbh/cot_fewshot/temporal_sequences.yaml
@@ -1,14 +1,7 @@
 dataset_name: temporal_sequences
-description: 'Task description: Answer questions about which times certain events
-  could have occurred.
-
-
-  '
-doc_to_text: 'Q: {{input}}
-
-  A: Let''s think step by step.
-
-  '
+description: "Task description: Answer questions about which times certain events could have occurred.\n\n"
+doc_to_text: "Q: {{input}}\n"
+gen_prefix: "A: Let's think step by step.\n"
 fewshot_config:
   sampler: first_n
   samples:

--- a/lm_eval/tasks/bbh/cot_fewshot/tracking_shuffled_objects_five_objects.yaml
+++ b/lm_eval/tasks/bbh/cot_fewshot/tracking_shuffled_objects_five_objects.yaml
@@ -1,14 +1,7 @@
 dataset_name: tracking_shuffled_objects_five_objects
-description: 'A task requiring determining the final positions of a set of objects
-  given their initial positions and a description of a sequence of swaps.
-
-
-  '
-doc_to_text: 'Q: {{input}}
-
-  A: Let''s think step by step.
-
-  '
+description: "A task requiring determining the final positions of a set of objects given their initial positions and a description of a sequence of swaps.\n\n"
+doc_to_text: "Q: {{input}}\n"
+gen_prefix: "A: Let's think step by step.\n"
 fewshot_config:
   sampler: first_n
   samples:

--- a/lm_eval/tasks/bbh/cot_fewshot/tracking_shuffled_objects_seven_objects.yaml
+++ b/lm_eval/tasks/bbh/cot_fewshot/tracking_shuffled_objects_seven_objects.yaml
@@ -1,14 +1,7 @@
 dataset_name: tracking_shuffled_objects_seven_objects
-description: 'A task requiring determining the final positions of a set of objects
-  given their initial positions and a description of a sequence of swaps.
-
-
-  '
-doc_to_text: 'Q: {{input}}
-
-  A: Let''s think step by step.
-
-  '
+description: "A task requiring determining the final positions of a set of objects given their initial positions and a description of a sequence of swaps.\n\n"
+doc_to_text: "Q: {{input}}\n"
+gen_prefix: "A: Let's think step by step.\n"
 fewshot_config:
   sampler: first_n
   samples:

--- a/lm_eval/tasks/bbh/cot_fewshot/tracking_shuffled_objects_three_objects.yaml
+++ b/lm_eval/tasks/bbh/cot_fewshot/tracking_shuffled_objects_three_objects.yaml
@@ -1,14 +1,7 @@
 dataset_name: tracking_shuffled_objects_three_objects
-description: 'A task requiring determining the final positions of a set of objects
-  given their initial positions and a description of a sequence of swaps.
-
-
-  '
-doc_to_text: 'Q: {{input}}
-
-  A: Let''s think step by step.
-
-  '
+description: "A task requiring determining the final positions of a set of objects given their initial positions and a description of a sequence of swaps.\n\n"
+doc_to_text: "Q: {{input}}\n"
+gen_prefix: "A: Let's think step by step.\n"
 fewshot_config:
   sampler: first_n
   samples:

--- a/lm_eval/tasks/bbh/cot_fewshot/web_of_lies.yaml
+++ b/lm_eval/tasks/bbh/cot_fewshot/web_of_lies.yaml
@@ -1,13 +1,7 @@
 dataset_name: web_of_lies
-description: 'Evaluate a random boolean function expressed as a word problem.
-
-
-  '
-doc_to_text: 'Q: {{input}}
-
-  A: Let''s think step by step.
-
-  '
+description: "Evaluate a random boolean function expressed as a word problem.\n\n"
+doc_to_text: "Q: {{input}}\n"
+gen_prefix: "A: Let's think step by step.\n"
 fewshot_config:
   sampler: first_n
   samples:

--- a/lm_eval/tasks/bbh/cot_fewshot/word_sorting.yaml
+++ b/lm_eval/tasks/bbh/cot_fewshot/word_sorting.yaml
@@ -1,13 +1,7 @@
 dataset_name: word_sorting
-description: 'Sort a list of words.
-
-
-  '
-doc_to_text: 'Q: {{input}}
-
-  A: Let''s think step by step.
-
-  '
+description: "Sort a list of words.\n\n"
+doc_to_text: "Q: {{input}}\n"
+gen_prefix: "A: Let's think step by step.\n"
 fewshot_config:
   sampler: first_n
   samples:

--- a/lm_eval/tasks/bbh/cot_zeroshot/boolean_expressions.yaml
+++ b/lm_eval/tasks/bbh/cot_zeroshot/boolean_expressions.yaml
@@ -1,6 +1,7 @@
 "dataset_name": "boolean_expressions"
 "description": "Evaluate the result of a random Boolean expression.\n\n"
-"doc_to_text": "Q: {{input}}\nA: Let's think step by step."
+doc_to_text: "Q: {{input}}\n"
+gen_prefix: "A: Let's think step by step.\n"
 "include": "_cot_zeroshot_template_yaml"
 "task": "bbh_cot_zeroshot_boolean_expressions"
 

--- a/lm_eval/tasks/bbh/cot_zeroshot/causal_judgement.yaml
+++ b/lm_eval/tasks/bbh/cot_zeroshot/causal_judgement.yaml
@@ -1,6 +1,7 @@
 "dataset_name": "causal_judgement"
 "description": "Answer questions about causal attribution.\n\n"
-"doc_to_text": "Q: {{input}}\nA: Let's think step by step."
+doc_to_text: "Q: {{input}}\n"
+gen_prefix: "A: Let's think step by step.\n"
 "include": "_cot_zeroshot_template_yaml"
 "task": "bbh_cot_zeroshot_causal_judgement"
 

--- a/lm_eval/tasks/bbh/cot_zeroshot/date_understanding.yaml
+++ b/lm_eval/tasks/bbh/cot_zeroshot/date_understanding.yaml
@@ -1,6 +1,7 @@
 "dataset_name": "date_understanding"
 "description": "Infer the date from context.\n\n"
-"doc_to_text": "Q: {{input}}\nA: Let's think step by step."
+doc_to_text: "Q: {{input}}\n"
+gen_prefix: "A: Let's think step by step.\n"
 "include": "_cot_zeroshot_template_yaml"
 "task": "bbh_cot_zeroshot_date_understanding"
 

--- a/lm_eval/tasks/bbh/cot_zeroshot/disambiguation_qa.yaml
+++ b/lm_eval/tasks/bbh/cot_zeroshot/disambiguation_qa.yaml
@@ -1,6 +1,7 @@
 "dataset_name": "disambiguation_qa"
 "description": "Clarify the meaning of sentences with ambiguous pronouns.\n\n"
-"doc_to_text": "Q: {{input}}\nA: Let's think step by step."
+doc_to_text: "Q: {{input}}\n"
+gen_prefix: "A: Let's think step by step.\n"
 "include": "_cot_zeroshot_template_yaml"
 "task": "bbh_cot_zeroshot_disambiguation_qa"
 

--- a/lm_eval/tasks/bbh/cot_zeroshot/dyck_languages.yaml
+++ b/lm_eval/tasks/bbh/cot_zeroshot/dyck_languages.yaml
@@ -1,6 +1,7 @@
 "dataset_name": "dyck_languages"
 "description": "Correctly close a Dyck-n word.\n\n"
-"doc_to_text": "Q: {{input}}\nA: Let's think step by step."
+doc_to_text: "Q: {{input}}\n"
+gen_prefix: "A: Let's think step by step.\n"
 "include": "_cot_zeroshot_template_yaml"
 "task": "bbh_cot_zeroshot_dyck_languages"
 filter_list:

--- a/lm_eval/tasks/bbh/cot_zeroshot/formal_fallacies.yaml
+++ b/lm_eval/tasks/bbh/cot_zeroshot/formal_fallacies.yaml
@@ -1,6 +1,7 @@
 "dataset_name": "formal_fallacies"
 "description": "Distinguish deductively valid arguments from formal fallacies.\n\n"
-"doc_to_text": "Q: {{input}}\nA: Let's think step by step."
+doc_to_text: "Q: {{input}}\n"
+gen_prefix: "A: Let's think step by step.\n"
 "include": "_cot_zeroshot_template_yaml"
 "task": "bbh_cot_zeroshot_formal_fallacies"
 

--- a/lm_eval/tasks/bbh/cot_zeroshot/geometric_shapes.yaml
+++ b/lm_eval/tasks/bbh/cot_zeroshot/geometric_shapes.yaml
@@ -1,6 +1,7 @@
 "dataset_name": "geometric_shapes"
 "description": "Name geometric shapes from their SVG paths.\n\n"
-"doc_to_text": "Q: {{input}}\nA: Let's think step by step."
+doc_to_text: "Q: {{input}}\n"
+gen_prefix: "A: Let's think step by step.\n"
 "include": "_cot_zeroshot_template_yaml"
 "task": "bbh_cot_zeroshot_geometric_shapes"
 

--- a/lm_eval/tasks/bbh/cot_zeroshot/hyperbaton.yaml
+++ b/lm_eval/tasks/bbh/cot_zeroshot/hyperbaton.yaml
@@ -1,6 +1,7 @@
 "dataset_name": "hyperbaton"
 "description": "Order adjectives correctly in English sentences.\n\n"
-"doc_to_text": "Q: {{input}}\nA: Let's think step by step."
+doc_to_text: "Q: {{input}}\n"
+gen_prefix: "A: Let's think step by step.\n"
 "include": "_cot_zeroshot_template_yaml"
 "task": "bbh_cot_zeroshot_hyperbaton"
 

--- a/lm_eval/tasks/bbh/cot_zeroshot/logical_deduction_five_objects.yaml
+++ b/lm_eval/tasks/bbh/cot_zeroshot/logical_deduction_five_objects.yaml
@@ -1,6 +1,7 @@
 "dataset_name": "logical_deduction_five_objects"
 "description": "A logical deduction task which requires deducing the order of a sequence of objects.\n\n"
-"doc_to_text": "Q: {{input}}\nA: Let's think step by step."
+doc_to_text: "Q: {{input}}\n"
+gen_prefix: "A: Let's think step by step.\n"
 "include": "_cot_zeroshot_template_yaml"
 "task": "bbh_cot_zeroshot_logical_deduction_five_objects"
 filter_list:

--- a/lm_eval/tasks/bbh/cot_zeroshot/logical_deduction_seven_objects.yaml
+++ b/lm_eval/tasks/bbh/cot_zeroshot/logical_deduction_seven_objects.yaml
@@ -1,6 +1,7 @@
 "dataset_name": "logical_deduction_seven_objects"
 "description": "A logical deduction task which requires deducing the order of a sequence of objects.\n\n"
-"doc_to_text": "Q: {{input}}\nA: Let's think step by step."
+doc_to_text: "Q: {{input}}\n"
+gen_prefix: "A: Let's think step by step.\n"
 "include": "_cot_zeroshot_template_yaml"
 "task": "bbh_cot_zeroshot_logical_deduction_seven_objects"
 filter_list:

--- a/lm_eval/tasks/bbh/cot_zeroshot/logical_deduction_three_objects.yaml
+++ b/lm_eval/tasks/bbh/cot_zeroshot/logical_deduction_three_objects.yaml
@@ -1,6 +1,7 @@
 "dataset_name": "logical_deduction_three_objects"
 "description": "A logical deduction task which requires deducing the order of a sequence of objects.\n\n"
-"doc_to_text": "Q: {{input}}\nA: Let's think step by step."
+doc_to_text: "Q: {{input}}\n"
+gen_prefix: "A: Let's think step by step.\n"
 "include": "_cot_zeroshot_template_yaml"
 "task": "bbh_cot_zeroshot_logical_deduction_three_objects"
 filter_list:

--- a/lm_eval/tasks/bbh/cot_zeroshot/movie_recommendation.yaml
+++ b/lm_eval/tasks/bbh/cot_zeroshot/movie_recommendation.yaml
@@ -1,6 +1,7 @@
 "dataset_name": "movie_recommendation"
 "description": "Recommend movies similar to the given list of movies.\n\n"
-"doc_to_text": "Q: {{input}}\nA: Let's think step by step."
+doc_to_text: "Q: {{input}}\n"
+gen_prefix: "A: Let's think step by step.\n"
 "include": "_cot_zeroshot_template_yaml"
 "task": "bbh_cot_zeroshot_movie_recommendation"
 filter_list:

--- a/lm_eval/tasks/bbh/cot_zeroshot/multistep_arithmetic_two.yaml
+++ b/lm_eval/tasks/bbh/cot_zeroshot/multistep_arithmetic_two.yaml
@@ -1,6 +1,7 @@
 "dataset_name": "multistep_arithmetic_two"
 "description": "Solve multi-step arithmetic problems.\n\n"
-"doc_to_text": "Q: {{input}}\nA: Let's think step by step."
+doc_to_text: "Q: {{input}}\n"
+gen_prefix: "A: Let's think step by step.\n"
 "include": "_cot_zeroshot_template_yaml"
 "task": "bbh_cot_zeroshot_multistep_arithmetic_two"
 

--- a/lm_eval/tasks/bbh/cot_zeroshot/navigate.yaml
+++ b/lm_eval/tasks/bbh/cot_zeroshot/navigate.yaml
@@ -1,6 +1,7 @@
 "dataset_name": "navigate"
 "description": "Given a series of navigation instructions, determine whether one would end up back at the starting point.\n\n"
-"doc_to_text": "Q: {{input}}\nA: Let's think step by step."
+doc_to_text: "Q: {{input}}\n"
+gen_prefix: "A: Let's think step by step.\n"
 "include": "_cot_zeroshot_template_yaml"
 "task": "bbh_cot_zeroshot_navigate"
 filter_list:

--- a/lm_eval/tasks/bbh/cot_zeroshot/object_counting.yaml
+++ b/lm_eval/tasks/bbh/cot_zeroshot/object_counting.yaml
@@ -1,6 +1,7 @@
 "dataset_name": "object_counting"
 "description": "Questions that involve enumerating objects and asking the model to count them.\n\n"
-"doc_to_text": "Q: {{input}}\nA: Let's think step by step."
+doc_to_text: "Q: {{input}}\n"
+gen_prefix: "A: Let's think step by step.\n"
 "include": "_cot_zeroshot_template_yaml"
 "task": "bbh_cot_zeroshot_object_counting"
 filter_list:

--- a/lm_eval/tasks/bbh/cot_zeroshot/penguins_in_a_table.yaml
+++ b/lm_eval/tasks/bbh/cot_zeroshot/penguins_in_a_table.yaml
@@ -1,6 +1,7 @@
 "dataset_name": "penguins_in_a_table"
 "description": "Answer questions about a table of penguins and their attributes.\n\n"
-"doc_to_text": "Q: {{input}}\nA: Let's think step by step."
+doc_to_text: "Q: {{input}}\n"
+gen_prefix: "A: Let's think step by step.\n"
 "include": "_cot_zeroshot_template_yaml"
 "task": "bbh_cot_zeroshot_penguins_in_a_table"
 filter_list:

--- a/lm_eval/tasks/bbh/cot_zeroshot/reasoning_about_colored_objects.yaml
+++ b/lm_eval/tasks/bbh/cot_zeroshot/reasoning_about_colored_objects.yaml
@@ -1,6 +1,7 @@
 "dataset_name": "reasoning_about_colored_objects"
 "description": "Answer extremely simple questions about the colors of objects on a surface.\n\n"
-"doc_to_text": "Q: {{input}}\nA: Let's think step by step."
+doc_to_text: "Q: {{input}}\n"
+gen_prefix: "A: Let's think step by step.\n"
 "include": "_cot_zeroshot_template_yaml"
 "task": "bbh_cot_zeroshot_reasoning_about_colored_objects"
 filter_list:

--- a/lm_eval/tasks/bbh/cot_zeroshot/ruin_names.yaml
+++ b/lm_eval/tasks/bbh/cot_zeroshot/ruin_names.yaml
@@ -1,6 +1,7 @@
 "dataset_name": "ruin_names"
 "description": "Select the humorous edit that 'ruins' the input movie or musical artist name.\n\n"
-"doc_to_text": "Q: {{input}}\nA: Let's think step by step."
+doc_to_text: "Q: {{input}}\n"
+gen_prefix: "A: Let's think step by step.\n"
 "include": "_cot_zeroshot_template_yaml"
 "task": "bbh_cot_zeroshot_ruin_names"
 filter_list:

--- a/lm_eval/tasks/bbh/cot_zeroshot/salient_translation_error_detection.yaml
+++ b/lm_eval/tasks/bbh/cot_zeroshot/salient_translation_error_detection.yaml
@@ -1,6 +1,7 @@
 "dataset_name": "salient_translation_error_detection"
 "description": "Detect the type of error in an English translation of a German source sentence.\n\n"
-"doc_to_text": "Q: {{input}}\nA: Let's think step by step."
+doc_to_text: "Q: {{input}}\n"
+gen_prefix: "A: Let's think step by step.\n"
 "include": "_cot_zeroshot_template_yaml"
 "task": "bbh_cot_zeroshot_salient_translation_error_detection"
 filter_list:

--- a/lm_eval/tasks/bbh/cot_zeroshot/snarks.yaml
+++ b/lm_eval/tasks/bbh/cot_zeroshot/snarks.yaml
@@ -1,6 +1,7 @@
 "dataset_name": "snarks"
 "description": "Determine which of two sentences is sarcastic.\n\nAccording to Cambridge University Dictionary, sarcasm is \"the use of remarks that clearly mean the opposite of what they say, made in order to hurt someone's feelings or to criticize something in a humorous way.\" Sarcastic sentences often contain satirical or ironic utterances, hyperboles, ambivalent or witty remarks.\n\n"
-"doc_to_text": "Q: {{input}}\nA: Let's think step by step."
+doc_to_text: "Q: {{input}}\n"
+gen_prefix: "A: Let's think step by step.\n"
 "include": "_cot_zeroshot_template_yaml"
 "task": "bbh_cot_zeroshot_snarks"
 filter_list:

--- a/lm_eval/tasks/bbh/cot_zeroshot/sports_understanding.yaml
+++ b/lm_eval/tasks/bbh/cot_zeroshot/sports_understanding.yaml
@@ -1,6 +1,7 @@
 "dataset_name": "sports_understanding"
 "description": "Determine whether an artificially constructed sentence relating to sports is plausible or not.\n\n"
-"doc_to_text": "Q: {{input}}\nA: Let's think step by step."
+doc_to_text: "Q: {{input}}\n"
+gen_prefix: "A: Let's think step by step.\n"
 "include": "_cot_zeroshot_template_yaml"
 "task": "bbh_cot_zeroshot_sports_understanding"
 

--- a/lm_eval/tasks/bbh/cot_zeroshot/temporal_sequences.yaml
+++ b/lm_eval/tasks/bbh/cot_zeroshot/temporal_sequences.yaml
@@ -1,6 +1,7 @@
 "dataset_name": "temporal_sequences"
 "description": "Task description: Answer questions about which times certain events could have occurred.\n\n"
-"doc_to_text": "Q: {{input}}\nA: Let's think step by step."
+doc_to_text: "Q: {{input}}\n"
+gen_prefix: "A: Let's think step by step.\n"
 "include": "_cot_zeroshot_template_yaml"
 "task": "bbh_cot_zeroshot_temporal_sequences"
 filter_list:

--- a/lm_eval/tasks/bbh/cot_zeroshot/tracking_shuffled_objects_five_objects.yaml
+++ b/lm_eval/tasks/bbh/cot_zeroshot/tracking_shuffled_objects_five_objects.yaml
@@ -1,6 +1,7 @@
 "dataset_name": "tracking_shuffled_objects_five_objects"
 "description": "A task requiring determining the final positions of a set of objects given their initial positions and a description of a sequence of swaps.\n\n"
-"doc_to_text": "Q: {{input}}\nA: Let's think step by step."
+doc_to_text: "Q: {{input}}\n"
+gen_prefix: "A: Let's think step by step.\n"
 "include": "_cot_zeroshot_template_yaml"
 "task": "bbh_cot_zeroshot_tracking_shuffled_objects_five_objects"
 filter_list:

--- a/lm_eval/tasks/bbh/cot_zeroshot/tracking_shuffled_objects_seven_objects.yaml
+++ b/lm_eval/tasks/bbh/cot_zeroshot/tracking_shuffled_objects_seven_objects.yaml
@@ -1,6 +1,7 @@
 "dataset_name": "tracking_shuffled_objects_seven_objects"
 "description": "A task requiring determining the final positions of a set of objects given their initial positions and a description of a sequence of swaps.\n\n"
-"doc_to_text": "Q: {{input}}\nA: Let's think step by step."
+doc_to_text: "Q: {{input}}\n"
+gen_prefix: "A: Let's think step by step.\n"
 "include": "_cot_zeroshot_template_yaml"
 "task": "bbh_cot_zeroshot_tracking_shuffled_objects_seven_objects"
 filter_list:

--- a/lm_eval/tasks/bbh/cot_zeroshot/tracking_shuffled_objects_three_objects.yaml
+++ b/lm_eval/tasks/bbh/cot_zeroshot/tracking_shuffled_objects_three_objects.yaml
@@ -1,6 +1,7 @@
 "dataset_name": "tracking_shuffled_objects_three_objects"
 "description": "A task requiring determining the final positions of a set of objects given their initial positions and a description of a sequence of swaps.\n\n"
-"doc_to_text": "Q: {{input}}\nA: Let's think step by step."
+doc_to_text: "Q: {{input}}\n"
+gen_prefix: "A: Let's think step by step.\n"
 "include": "_cot_zeroshot_template_yaml"
 "task": "bbh_cot_zeroshot_tracking_shuffled_objects_three_objects"
 filter_list:

--- a/lm_eval/tasks/bbh/cot_zeroshot/web_of_lies.yaml
+++ b/lm_eval/tasks/bbh/cot_zeroshot/web_of_lies.yaml
@@ -1,6 +1,7 @@
 "dataset_name": "web_of_lies"
 "description": "Evaluate a random boolean function expressed as a word problem.\n\n"
-"doc_to_text": "Q: {{input}}\nA: Let's think step by step."
+doc_to_text: "Q: {{input}}\n"
+gen_prefix: "A: Let's think step by step.\n"
 "include": "_cot_zeroshot_template_yaml"
 "task": "bbh_cot_zeroshot_web_of_lies"
 filter_list:

--- a/lm_eval/tasks/bbh/cot_zeroshot/word_sorting.yaml
+++ b/lm_eval/tasks/bbh/cot_zeroshot/word_sorting.yaml
@@ -1,6 +1,7 @@
 "dataset_name": "word_sorting"
 "description": "Sort a list of words.\n\n"
-"doc_to_text": "Q: {{input}}\nA: Let's think step by step."
+doc_to_text: "Q: {{input}}\n"
+gen_prefix: "A: Let's think step by step.\n"
 "include": "_cot_zeroshot_template_yaml"
 "task": "bbh_cot_zeroshot_word_sorting"
 filter_list:

--- a/lm_eval/tasks/bbh/fewshot/_fewshot_template_yaml
+++ b/lm_eval/tasks/bbh/fewshot/_fewshot_template_yaml
@@ -12,7 +12,7 @@ generation_kwargs:
   until:
     - "</s>"
     - "Q"
-    - "\n\n"
+#    - "\n\n"
   do_sample: false
   temperature: 0.0
 num_fewshot: 3

--- a/lm_eval/tasks/bbh/fewshot/boolean_expressions.yaml
+++ b/lm_eval/tasks/bbh/fewshot/boolean_expressions.yaml
@@ -1,11 +1,7 @@
 dataset_name: boolean_expressions
-description: 'Evaluate the result of a random Boolean expression.
-
-
-  '
-doc_to_text: 'Q: {{input}}
-
-  A:'
+description: "Evaluate the result of a random Boolean expression.\n\n"
+doc_to_text: "Q: {{input}}\n"
+gen_prefix: "A:"
 fewshot_config:
   sampler: first_n
   samples:

--- a/lm_eval/tasks/bbh/fewshot/causal_judgement.yaml
+++ b/lm_eval/tasks/bbh/fewshot/causal_judgement.yaml
@@ -1,11 +1,7 @@
 dataset_name: causal_judgement
-description: 'Answer questions about causal attribution.
-
-
-  '
-doc_to_text: 'Q: {{input}}
-
-  A:'
+description: "Answer questions about causal attribution.\n\n"
+doc_to_text: "Q: {{input}}\n"
+gen_prefix: "A:"
 fewshot_config:
   sampler: first_n
   samples:

--- a/lm_eval/tasks/bbh/fewshot/date_understanding.yaml
+++ b/lm_eval/tasks/bbh/fewshot/date_understanding.yaml
@@ -1,11 +1,7 @@
 dataset_name: date_understanding
-description: 'Infer the date from context.
-
-
-  '
-doc_to_text: 'Q: {{input}}
-
-  A:'
+description: "Infer the date from context.\n\n"
+doc_to_text: "Q: {{input}}\n"
+gen_prefix: "A:"
 fewshot_config:
   sampler: first_n
   samples:

--- a/lm_eval/tasks/bbh/fewshot/disambiguation_qa.yaml
+++ b/lm_eval/tasks/bbh/fewshot/disambiguation_qa.yaml
@@ -1,11 +1,7 @@
 dataset_name: disambiguation_qa
-description: 'Clarify the meaning of sentences with ambiguous pronouns.
-
-
-  '
-doc_to_text: 'Q: {{input}}
-
-  A:'
+description: "Clarify the meaning of sentences with ambiguous pronouns.\n\n"
+doc_to_text: "Q: {{input}}\n"
+gen_prefix: "A:"
 fewshot_config:
   sampler: first_n
   samples:

--- a/lm_eval/tasks/bbh/fewshot/dyck_languages.yaml
+++ b/lm_eval/tasks/bbh/fewshot/dyck_languages.yaml
@@ -1,11 +1,7 @@
 dataset_name: dyck_languages
-description: 'Correctly close a Dyck-n word.
-
-
-  '
-doc_to_text: 'Q: {{input}}
-
-  A:'
+description: "Correctly close a Dyck-n word.\n\n"
+doc_to_text: "Q: {{input}}\n"
+gen_prefix: "A:"
 fewshot_config:
   sampler: first_n
   samples:

--- a/lm_eval/tasks/bbh/fewshot/formal_fallacies.yaml
+++ b/lm_eval/tasks/bbh/fewshot/formal_fallacies.yaml
@@ -1,11 +1,7 @@
 dataset_name: formal_fallacies
-description: 'Distinguish deductively valid arguments from formal fallacies.
-
-
-  '
-doc_to_text: 'Q: {{input}}
-
-  A:'
+description: "Distinguish deductively valid arguments from formal fallacies.\n\n"
+doc_to_text: "Q: {{input}}\n"
+gen_prefix: "A:"
 fewshot_config:
   sampler: first_n
   samples:

--- a/lm_eval/tasks/bbh/fewshot/geometric_shapes.yaml
+++ b/lm_eval/tasks/bbh/fewshot/geometric_shapes.yaml
@@ -1,11 +1,7 @@
 dataset_name: geometric_shapes
-description: 'Name geometric shapes from their SVG paths.
-
-
-  '
-doc_to_text: 'Q: {{input}}
-
-  A:'
+description: "Name geometric shapes from their SVG paths.\n\n"
+doc_to_text: "Q: {{input}}\n"
+gen_prefix: "A:"
 fewshot_config:
   sampler: first_n
   samples:

--- a/lm_eval/tasks/bbh/fewshot/hyperbaton.yaml
+++ b/lm_eval/tasks/bbh/fewshot/hyperbaton.yaml
@@ -1,11 +1,7 @@
 dataset_name: hyperbaton
-description: 'Order adjectives correctly in English sentences.
-
-
-  '
-doc_to_text: 'Q: {{input}}
-
-  A:'
+description: "Order adjectives correctly in English sentences.\n\n"
+doc_to_text: "Q: {{input}}\n"
+gen_prefix: "A:"
 fewshot_config:
   sampler: first_n
   samples:

--- a/lm_eval/tasks/bbh/fewshot/logical_deduction_five_objects.yaml
+++ b/lm_eval/tasks/bbh/fewshot/logical_deduction_five_objects.yaml
@@ -1,12 +1,8 @@
 dataset_name: logical_deduction_five_objects
-description: 'A logical deduction task which requires deducing the order of a sequence
-  of objects.
-
-
-  '
-doc_to_text: 'Q: {{input}}
-
-  A:'
+description: "A logical deduction task which requires deducing the order of a sequence
+  of objects.\n\n"
+doc_to_text: "Q: {{input}}\n"
+gen_prefix: "A:"
 fewshot_config:
   sampler: first_n
   samples:

--- a/lm_eval/tasks/bbh/fewshot/logical_deduction_seven_objects.yaml
+++ b/lm_eval/tasks/bbh/fewshot/logical_deduction_seven_objects.yaml
@@ -1,12 +1,8 @@
 dataset_name: logical_deduction_seven_objects
-description: 'A logical deduction task which requires deducing the order of a sequence
-  of objects.
-
-
-  '
-doc_to_text: 'Q: {{input}}
-
-  A:'
+description: "A logical deduction task which requires deducing the order of a sequence
+  of objects.\n\n"
+doc_to_text: "Q: {{input}}\n"
+gen_prefix: "A:"
 fewshot_config:
   sampler: first_n
   samples:

--- a/lm_eval/tasks/bbh/fewshot/logical_deduction_three_objects.yaml
+++ b/lm_eval/tasks/bbh/fewshot/logical_deduction_three_objects.yaml
@@ -1,12 +1,8 @@
 dataset_name: logical_deduction_three_objects
-description: 'A logical deduction task which requires deducing the order of a sequence
-  of objects.
-
-
-  '
-doc_to_text: 'Q: {{input}}
-
-  A:'
+description: "A logical deduction task which requires deducing the order of a sequence
+  of objects.\n\n"
+doc_to_text: "Q: {{input}}\n"
+gen_prefix: "A:"
 fewshot_config:
   sampler: first_n
   samples:

--- a/lm_eval/tasks/bbh/fewshot/movie_recommendation.yaml
+++ b/lm_eval/tasks/bbh/fewshot/movie_recommendation.yaml
@@ -1,11 +1,7 @@
 dataset_name: movie_recommendation
-description: 'Recommend movies similar to the given list of movies.
-
-
-  '
-doc_to_text: 'Q: {{input}}
-
-  A:'
+description: "Recommend movies similar to the given list of movies.\n\n"
+doc_to_text: "Q: {{input}}\n"
+gen_prefix: "A:"
 fewshot_config:
   sampler: first_n
   samples:

--- a/lm_eval/tasks/bbh/fewshot/multistep_arithmetic_two.yaml
+++ b/lm_eval/tasks/bbh/fewshot/multistep_arithmetic_two.yaml
@@ -1,11 +1,7 @@
 dataset_name: multistep_arithmetic_two
-description: 'Solve multi-step arithmetic problems.
-
-
-  '
-doc_to_text: 'Q: {{input}}
-
-  A:'
+description: "Solve multi-step arithmetic problems.\n\n"
+doc_to_text: "Q: {{input}}\n"
+gen_prefix: "A:"
 fewshot_config:
   sampler: first_n
   samples:

--- a/lm_eval/tasks/bbh/fewshot/navigate.yaml
+++ b/lm_eval/tasks/bbh/fewshot/navigate.yaml
@@ -1,12 +1,8 @@
 dataset_name: navigate
-description: 'Given a series of navigation instructions, determine whether one would
-  end up back at the starting point.
-
-
-  '
-doc_to_text: 'Q: {{input}}
-
-  A:'
+description: "Given a series of navigation instructions, determine whether one would
+  end up back at the starting point.\n\n"
+doc_to_text: "Q: {{input}}\n"
+gen_prefix: "A:"
 fewshot_config:
   sampler: first_n
   samples:

--- a/lm_eval/tasks/bbh/fewshot/object_counting.yaml
+++ b/lm_eval/tasks/bbh/fewshot/object_counting.yaml
@@ -1,12 +1,8 @@
 dataset_name: object_counting
-description: 'Questions that involve enumerating objects and asking the model to count
-  them.
-
-
-  '
-doc_to_text: 'Q: {{input}}
-
-  A:'
+description: "Questions that involve enumerating objects and asking the model to count
+  them.\n\n"
+doc_to_text: "Q: {{input}}\n"
+gen_prefix: "A:"
 fewshot_config:
   sampler: first_n
   samples:

--- a/lm_eval/tasks/bbh/fewshot/penguins_in_a_table.yaml
+++ b/lm_eval/tasks/bbh/fewshot/penguins_in_a_table.yaml
@@ -1,11 +1,7 @@
 dataset_name: penguins_in_a_table
-description: 'Answer questions about a table of penguins and their attributes.
-
-
-  '
-doc_to_text: 'Q: {{input}}
-
-  A:'
+description: "Answer questions about a table of penguins and their attributes.\n\n"
+doc_to_text: "Q: {{input}}\n"
+gen_prefix: "A:"
 fewshot_config:
   sampler: first_n
   samples:

--- a/lm_eval/tasks/bbh/fewshot/reasoning_about_colored_objects.yaml
+++ b/lm_eval/tasks/bbh/fewshot/reasoning_about_colored_objects.yaml
@@ -1,11 +1,7 @@
 dataset_name: reasoning_about_colored_objects
-description: 'Answer extremely simple questions about the colors of objects on a surface.
-
-
-  '
-doc_to_text: 'Q: {{input}}
-
-  A:'
+description: "Answer extremely simple questions about the colors of objects on a surface.\n\n"
+doc_to_text: "Q: {{input}}\n"
+gen_prefix: "A:"
 fewshot_config:
   sampler: first_n
   samples:

--- a/lm_eval/tasks/bbh/fewshot/ruin_names.yaml
+++ b/lm_eval/tasks/bbh/fewshot/ruin_names.yaml
@@ -1,12 +1,8 @@
 dataset_name: ruin_names
-description: 'Select the humorous edit that ''ruins'' the input movie or musical artist
-  name.
-
-
-  '
-doc_to_text: 'Q: {{input}}
-
-  A:'
+description: "Select the humorous edit that ''ruins'' the input movie or musical artist
+  name.\n\n"
+doc_to_text: "Q: {{input}}\n"
+gen_prefix: "A:"
 fewshot_config:
   sampler: first_n
   samples:

--- a/lm_eval/tasks/bbh/fewshot/salient_translation_error_detection.yaml
+++ b/lm_eval/tasks/bbh/fewshot/salient_translation_error_detection.yaml
@@ -1,12 +1,8 @@
 dataset_name: salient_translation_error_detection
-description: 'Detect the type of error in an English translation of a German source
-  sentence.
-
-
-  '
-doc_to_text: 'Q: {{input}}
-
-  A:'
+description: "Detect the type of error in an English translation of a German source
+  sentence.\n\n"
+doc_to_text: "Q: {{input}}\n"
+gen_prefix: "A:"
 fewshot_config:
   sampler: first_n
   samples:

--- a/lm_eval/tasks/bbh/fewshot/snarks.yaml
+++ b/lm_eval/tasks/bbh/fewshot/snarks.yaml
@@ -1,17 +1,13 @@
 dataset_name: snarks
-description: 'Determine which of two sentences is sarcastic.
+description: "Determine which of two sentences is sarcastic.
 
 
-  According to Cambridge University Dictionary, sarcasm is "the use of remarks that
+  According to Cambridge University Dictionary, sarcasm is ''the use of remarks that
   clearly mean the opposite of what they say, made in order to hurt someone''s feelings
-  or to criticize something in a humorous way." Sarcastic sentences often contain
-  satirical or ironic utterances, hyperboles, ambivalent or witty remarks.
-
-
-  '
-doc_to_text: 'Q: {{input}}
-
-  A:'
+  or to criticize something in a humorous way.'' Sarcastic sentences often contain
+  satirical or ironic utterances, hyperboles, ambivalent or witty remarks.\n\n"
+doc_to_text: "Q: {{input}}\n"
+gen_prefix: "A:"
 fewshot_config:
   sampler: first_n
   samples:

--- a/lm_eval/tasks/bbh/fewshot/sports_understanding.yaml
+++ b/lm_eval/tasks/bbh/fewshot/sports_understanding.yaml
@@ -1,12 +1,8 @@
 dataset_name: sports_understanding
-description: 'Determine whether an artificially constructed sentence relating to sports
-  is plausible or not.
-
-
-  '
-doc_to_text: 'Q: {{input}}
-
-  A:'
+description: "Determine whether an artificially constructed sentence relating to sports
+  is plausible or not.\n\n"
+doc_to_text: "Q: {{input}}\n"
+gen_prefix: "A:"
 fewshot_config:
   sampler: first_n
   samples:

--- a/lm_eval/tasks/bbh/fewshot/temporal_sequences.yaml
+++ b/lm_eval/tasks/bbh/fewshot/temporal_sequences.yaml
@@ -1,12 +1,8 @@
 dataset_name: temporal_sequences
-description: 'Task description: Answer questions about which times certain events
-  could have occurred.
-
-
-  '
-doc_to_text: 'Q: {{input}}
-
-  A:'
+description: "Task description: Answer questions about which times certain events
+  could have occurred.\n\n"
+doc_to_text: "Q: {{input}}\n"
+gen_prefix: "A:"
 fewshot_config:
   sampler: first_n
   samples:

--- a/lm_eval/tasks/bbh/fewshot/tracking_shuffled_objects_five_objects.yaml
+++ b/lm_eval/tasks/bbh/fewshot/tracking_shuffled_objects_five_objects.yaml
@@ -1,12 +1,8 @@
 dataset_name: tracking_shuffled_objects_five_objects
-description: 'A task requiring determining the final positions of a set of objects
-  given their initial positions and a description of a sequence of swaps.
-
-
-  '
-doc_to_text: 'Q: {{input}}
-
-  A:'
+description: "A task requiring determining the final positions of a set of objects
+  given their initial positions and a description of a sequence of swaps.\n\n"
+doc_to_text: "Q: {{input}}\n"
+gen_prefix: "A:"
 fewshot_config:
   sampler: first_n
   samples:

--- a/lm_eval/tasks/bbh/fewshot/tracking_shuffled_objects_seven_objects.yaml
+++ b/lm_eval/tasks/bbh/fewshot/tracking_shuffled_objects_seven_objects.yaml
@@ -1,12 +1,8 @@
 dataset_name: tracking_shuffled_objects_seven_objects
-description: 'A task requiring determining the final positions of a set of objects
-  given their initial positions and a description of a sequence of swaps.
-
-
-  '
-doc_to_text: 'Q: {{input}}
-
-  A:'
+description: "A task requiring determining the final positions of a set of objects
+  given their initial positions and a description of a sequence of swaps.\n\n"
+doc_to_text: "Q: {{input}}\n"
+gen_prefix: "A:"
 fewshot_config:
   sampler: first_n
   samples:

--- a/lm_eval/tasks/bbh/fewshot/tracking_shuffled_objects_three_objects.yaml
+++ b/lm_eval/tasks/bbh/fewshot/tracking_shuffled_objects_three_objects.yaml
@@ -1,12 +1,8 @@
 dataset_name: tracking_shuffled_objects_three_objects
-description: 'A task requiring determining the final positions of a set of objects
-  given their initial positions and a description of a sequence of swaps.
-
-
-  '
-doc_to_text: 'Q: {{input}}
-
-  A:'
+description: "A task requiring determining the final positions of a set of objects
+  given their initial positions and a description of a sequence of swaps.\n\n"
+doc_to_text: "Q: {{input}}\n"
+gen_prefix: "A:"
 fewshot_config:
   sampler: first_n
   samples:

--- a/lm_eval/tasks/bbh/fewshot/web_of_lies.yaml
+++ b/lm_eval/tasks/bbh/fewshot/web_of_lies.yaml
@@ -1,11 +1,7 @@
 dataset_name: web_of_lies
-description: 'Evaluate a random boolean function expressed as a word problem.
-
-
-  '
-doc_to_text: 'Q: {{input}}
-
-  A:'
+description: "Evaluate a random boolean function expressed as a word problem.\n\n"
+doc_to_text: "Q: {{input}}\n"
+gen_prefix: "A:"
 fewshot_config:
   sampler: first_n
   samples:

--- a/lm_eval/tasks/bbh/fewshot/word_sorting.yaml
+++ b/lm_eval/tasks/bbh/fewshot/word_sorting.yaml
@@ -1,11 +1,7 @@
 dataset_name: word_sorting
-description: 'Sort a list of words.
-
-
-  '
-doc_to_text: 'Q: {{input}}
-
-  A:'
+description: "Sort a list of words.\n\n"
+doc_to_text: "Q: {{input}}\n"
+gen_prefix: "A:"
 fewshot_config:
   sampler: first_n
   samples:

--- a/lm_eval/tasks/bbh/zeroshot/boolean_expressions.yaml
+++ b/lm_eval/tasks/bbh/zeroshot/boolean_expressions.yaml
@@ -1,6 +1,7 @@
 "dataset_name": "boolean_expressions"
 "description": "Evaluate the result of a random Boolean expression.\n\n"
-"doc_to_text": "Q: {{input}}\nA:"
+doc_to_text: "Q: {{input}}\n"
+gen_prefix: "A:"
 "include": "_zeroshot_template_yaml"
 "task": "bbh_zeroshot_boolean_expressions"
 

--- a/lm_eval/tasks/bbh/zeroshot/causal_judgement.yaml
+++ b/lm_eval/tasks/bbh/zeroshot/causal_judgement.yaml
@@ -1,6 +1,7 @@
 "dataset_name": "causal_judgement"
 "description": "Answer questions about causal attribution.\n\n"
-"doc_to_text": "Q: {{input}}\nA:"
+doc_to_text: "Q: {{input}}\n"
+gen_prefix: "A:"
 "include": "_zeroshot_template_yaml"
 "task": "bbh_zeroshot_causal_judgement"
 

--- a/lm_eval/tasks/bbh/zeroshot/date_understanding.yaml
+++ b/lm_eval/tasks/bbh/zeroshot/date_understanding.yaml
@@ -1,6 +1,7 @@
 "dataset_name": "date_understanding"
 "description": "Infer the date from context.\n\n"
-"doc_to_text": "Q: {{input}}\nA:"
+doc_to_text: "Q: {{input}}\n"
+gen_prefix: "A:"
 "include": "_zeroshot_template_yaml"
 "task": "bbh_zeroshot_date_understanding"
 

--- a/lm_eval/tasks/bbh/zeroshot/disambiguation_qa.yaml
+++ b/lm_eval/tasks/bbh/zeroshot/disambiguation_qa.yaml
@@ -1,6 +1,7 @@
 "dataset_name": "disambiguation_qa"
 "description": "Clarify the meaning of sentences with ambiguous pronouns.\n\n"
-"doc_to_text": "Q: {{input}}\nA:"
+doc_to_text: "Q: {{input}}\n"
+gen_prefix: "A:"
 "include": "_zeroshot_template_yaml"
 "task": "bbh_zeroshot_disambiguation_qa"
 

--- a/lm_eval/tasks/bbh/zeroshot/dyck_languages.yaml
+++ b/lm_eval/tasks/bbh/zeroshot/dyck_languages.yaml
@@ -1,6 +1,7 @@
 "dataset_name": "dyck_languages"
 "description": "Correctly close a Dyck-n word.\n\n"
-"doc_to_text": "Q: {{input}}\nA:"
+doc_to_text: "Q: {{input}}\n"
+gen_prefix: "A:"
 "include": "_zeroshot_template_yaml"
 "task": "bbh_zeroshot_dyck_languages"
 filter_list:

--- a/lm_eval/tasks/bbh/zeroshot/formal_fallacies.yaml
+++ b/lm_eval/tasks/bbh/zeroshot/formal_fallacies.yaml
@@ -1,6 +1,7 @@
 "dataset_name": "formal_fallacies"
 "description": "Distinguish deductively valid arguments from formal fallacies.\n\n"
-"doc_to_text": "Q: {{input}}\nA:"
+doc_to_text: "Q: {{input}}\n"
+gen_prefix: "A:"
 "include": "_zeroshot_template_yaml"
 "task": "bbh_zeroshot_formal_fallacies"
 

--- a/lm_eval/tasks/bbh/zeroshot/geometric_shapes.yaml
+++ b/lm_eval/tasks/bbh/zeroshot/geometric_shapes.yaml
@@ -1,6 +1,7 @@
 "dataset_name": "geometric_shapes"
 "description": "Name geometric shapes from their SVG paths.\n\n"
-"doc_to_text": "Q: {{input}}\nA:"
+doc_to_text: "Q: {{input}}\n"
+gen_prefix: "A:"
 "include": "_zeroshot_template_yaml"
 "task": "bbh_zeroshot_geometric_shapes"
 

--- a/lm_eval/tasks/bbh/zeroshot/hyperbaton.yaml
+++ b/lm_eval/tasks/bbh/zeroshot/hyperbaton.yaml
@@ -1,6 +1,7 @@
 "dataset_name": "hyperbaton"
 "description": "Order adjectives correctly in English sentences.\n\n"
-"doc_to_text": "Q: {{input}}\nA:"
+doc_to_text: "Q: {{input}}\n"
+gen_prefix: "A:"
 "include": "_zeroshot_template_yaml"
 "task": "bbh_zeroshot_hyperbaton"
 

--- a/lm_eval/tasks/bbh/zeroshot/logical_deduction_five_objects.yaml
+++ b/lm_eval/tasks/bbh/zeroshot/logical_deduction_five_objects.yaml
@@ -1,6 +1,7 @@
 "dataset_name": "logical_deduction_five_objects"
 "description": "A logical deduction task which requires deducing the order of a sequence of objects.\n\n"
-"doc_to_text": "Q: {{input}}\nA:"
+doc_to_text: "Q: {{input}}\n"
+gen_prefix: "A:"
 "include": "_zeroshot_template_yaml"
 "task": "bbh_zeroshot_logical_deduction_five_objects"
 filter_list:

--- a/lm_eval/tasks/bbh/zeroshot/logical_deduction_seven_objects.yaml
+++ b/lm_eval/tasks/bbh/zeroshot/logical_deduction_seven_objects.yaml
@@ -1,6 +1,7 @@
 "dataset_name": "logical_deduction_seven_objects"
 "description": "A logical deduction task which requires deducing the order of a sequence of objects.\n\n"
-"doc_to_text": "Q: {{input}}\nA:"
+doc_to_text: "Q: {{input}}\n"
+gen_prefix: "A:"
 "include": "_zeroshot_template_yaml"
 "task": "bbh_zeroshot_logical_deduction_seven_objects"
 filter_list:

--- a/lm_eval/tasks/bbh/zeroshot/logical_deduction_three_objects.yaml
+++ b/lm_eval/tasks/bbh/zeroshot/logical_deduction_three_objects.yaml
@@ -1,6 +1,7 @@
 "dataset_name": "logical_deduction_three_objects"
 "description": "A logical deduction task which requires deducing the order of a sequence of objects.\n\n"
-"doc_to_text": "Q: {{input}}\nA:"
+doc_to_text: "Q: {{input}}\n"
+gen_prefix: "A:"
 "include": "_zeroshot_template_yaml"
 "task": "bbh_zeroshot_logical_deduction_three_objects"
 filter_list:

--- a/lm_eval/tasks/bbh/zeroshot/movie_recommendation.yaml
+++ b/lm_eval/tasks/bbh/zeroshot/movie_recommendation.yaml
@@ -1,6 +1,7 @@
 "dataset_name": "movie_recommendation"
 "description": "Recommend movies similar to the given list of movies.\n\n"
-"doc_to_text": "Q: {{input}}\nA:"
+doc_to_text: "Q: {{input}}\n"
+gen_prefix: "A:"
 "include": "_zeroshot_template_yaml"
 "task": "bbh_zeroshot_movie_recommendation"
 filter_list:

--- a/lm_eval/tasks/bbh/zeroshot/multistep_arithmetic_two.yaml
+++ b/lm_eval/tasks/bbh/zeroshot/multistep_arithmetic_two.yaml
@@ -1,6 +1,7 @@
 "dataset_name": "multistep_arithmetic_two"
 "description": "Solve multi-step arithmetic problems.\n\n"
-"doc_to_text": "Q: {{input}}\nA:"
+doc_to_text: "Q: {{input}}\n"
+gen_prefix: "A:"
 "include": "_zeroshot_template_yaml"
 "task": "bbh_zeroshot_multistep_arithmetic_two"
 

--- a/lm_eval/tasks/bbh/zeroshot/navigate.yaml
+++ b/lm_eval/tasks/bbh/zeroshot/navigate.yaml
@@ -1,6 +1,7 @@
 "dataset_name": "navigate"
 "description": "Given a series of navigation instructions, determine whether one would end up back at the starting point.\n\n"
-"doc_to_text": "Q: {{input}}\nA:"
+doc_to_text: "Q: {{input}}\n"
+gen_prefix: "A:"
 "include": "_zeroshot_template_yaml"
 "task": "bbh_zeroshot_navigate"
 filter_list:

--- a/lm_eval/tasks/bbh/zeroshot/object_counting.yaml
+++ b/lm_eval/tasks/bbh/zeroshot/object_counting.yaml
@@ -1,6 +1,7 @@
 "dataset_name": "object_counting"
 "description": "Questions that involve enumerating objects and asking the model to count them.\n\n"
-"doc_to_text": "Q: {{input}}\nA:"
+doc_to_text: "Q: {{input}}\n"
+gen_prefix: "A:"
 "include": "_zeroshot_template_yaml"
 "task": "bbh_zeroshot_object_counting"
 filter_list:

--- a/lm_eval/tasks/bbh/zeroshot/penguins_in_a_table.yaml
+++ b/lm_eval/tasks/bbh/zeroshot/penguins_in_a_table.yaml
@@ -1,6 +1,7 @@
 "dataset_name": "penguins_in_a_table"
 "description": "Answer questions about a table of penguins and their attributes.\n\n"
-"doc_to_text": "Q: {{input}}\nA:"
+doc_to_text: "Q: {{input}}\n"
+gen_prefix: "A:"
 "include": "_zeroshot_template_yaml"
 "task": "bbh_zeroshot_penguins_in_a_table"
 filter_list:

--- a/lm_eval/tasks/bbh/zeroshot/reasoning_about_colored_objects.yaml
+++ b/lm_eval/tasks/bbh/zeroshot/reasoning_about_colored_objects.yaml
@@ -1,6 +1,7 @@
 "dataset_name": "reasoning_about_colored_objects"
 "description": "Answer extremely simple questions about the colors of objects on a surface.\n\n"
-"doc_to_text": "Q: {{input}}\nA:"
+doc_to_text: "Q: {{input}}\n"
+gen_prefix: "A:"
 "include": "_zeroshot_template_yaml"
 "task": "bbh_zeroshot_reasoning_about_colored_objects"
 filter_list:

--- a/lm_eval/tasks/bbh/zeroshot/ruin_names.yaml
+++ b/lm_eval/tasks/bbh/zeroshot/ruin_names.yaml
@@ -1,6 +1,7 @@
 "dataset_name": "ruin_names"
 "description": "Select the humorous edit that 'ruins' the input movie or musical artist name.\n\n"
-"doc_to_text": "Q: {{input}}\nA:"
+doc_to_text: "Q: {{input}}\n"
+gen_prefix: "A:"
 "include": "_zeroshot_template_yaml"
 "task": "bbh_zeroshot_ruin_names"
 filter_list:

--- a/lm_eval/tasks/bbh/zeroshot/salient_translation_error_detection.yaml
+++ b/lm_eval/tasks/bbh/zeroshot/salient_translation_error_detection.yaml
@@ -1,6 +1,7 @@
 "dataset_name": "salient_translation_error_detection"
 "description": "Detect the type of error in an English translation of a German source sentence.\n\n"
-"doc_to_text": "Q: {{input}}\nA:"
+doc_to_text: "Q: {{input}}\n"
+gen_prefix: "A:"
 "include": "_zeroshot_template_yaml"
 "task": "bbh_zeroshot_salient_translation_error_detection"
 filter_list:

--- a/lm_eval/tasks/bbh/zeroshot/snarks.yaml
+++ b/lm_eval/tasks/bbh/zeroshot/snarks.yaml
@@ -1,6 +1,7 @@
 "dataset_name": "snarks"
 "description": "Determine which of two sentences is sarcastic.\n\nAccording to Cambridge University Dictionary, sarcasm is \"the use of remarks that clearly mean the opposite of what they say, made in order to hurt someone's feelings or to criticize something in a humorous way.\" Sarcastic sentences often contain satirical or ironic utterances, hyperboles, ambivalent or witty remarks.\n\n"
-"doc_to_text": "Q: {{input}}\nA:"
+doc_to_text: "Q: {{input}}\n"
+gen_prefix: "A:"
 "include": "_zeroshot_template_yaml"
 "task": "bbh_zeroshot_snarks"
 filter_list:

--- a/lm_eval/tasks/bbh/zeroshot/sports_understanding.yaml
+++ b/lm_eval/tasks/bbh/zeroshot/sports_understanding.yaml
@@ -1,6 +1,7 @@
 "dataset_name": "sports_understanding"
 "description": "Determine whether an artificially constructed sentence relating to sports is plausible or not.\n\n"
-"doc_to_text": "Q: {{input}}\nA:"
+doc_to_text: "Q: {{input}}\n"
+gen_prefix: "A:"
 "include": "_zeroshot_template_yaml"
 "task": "bbh_zeroshot_sports_understanding"
 

--- a/lm_eval/tasks/bbh/zeroshot/temporal_sequences.yaml
+++ b/lm_eval/tasks/bbh/zeroshot/temporal_sequences.yaml
@@ -1,6 +1,7 @@
 "dataset_name": "temporal_sequences"
 "description": "Task description: Answer questions about which times certain events could have occurred.\n\n"
-"doc_to_text": "Q: {{input}}\nA:"
+doc_to_text: "Q: {{input}}\n"
+gen_prefix: "A:"
 "include": "_zeroshot_template_yaml"
 "task": "bbh_zeroshot_temporal_sequences"
 filter_list:

--- a/lm_eval/tasks/bbh/zeroshot/tracking_shuffled_objects_five_objects.yaml
+++ b/lm_eval/tasks/bbh/zeroshot/tracking_shuffled_objects_five_objects.yaml
@@ -1,6 +1,7 @@
 "dataset_name": "tracking_shuffled_objects_five_objects"
 "description": "A task requiring determining the final positions of a set of objects given their initial positions and a description of a sequence of swaps.\n\n"
-"doc_to_text": "Q: {{input}}\nA:"
+doc_to_text: "Q: {{input}}\n"
+gen_prefix: "A:"
 "include": "_zeroshot_template_yaml"
 "task": "bbh_zeroshot_tracking_shuffled_objects_five_objects"
 filter_list:

--- a/lm_eval/tasks/bbh/zeroshot/tracking_shuffled_objects_seven_objects.yaml
+++ b/lm_eval/tasks/bbh/zeroshot/tracking_shuffled_objects_seven_objects.yaml
@@ -1,6 +1,7 @@
 "dataset_name": "tracking_shuffled_objects_seven_objects"
 "description": "A task requiring determining the final positions of a set of objects given their initial positions and a description of a sequence of swaps.\n\n"
-"doc_to_text": "Q: {{input}}\nA:"
+doc_to_text: "Q: {{input}}\n"
+gen_prefix: "A:"
 "include": "_zeroshot_template_yaml"
 "task": "bbh_zeroshot_tracking_shuffled_objects_seven_objects"
 filter_list:

--- a/lm_eval/tasks/bbh/zeroshot/tracking_shuffled_objects_three_objects.yaml
+++ b/lm_eval/tasks/bbh/zeroshot/tracking_shuffled_objects_three_objects.yaml
@@ -1,6 +1,7 @@
 "dataset_name": "tracking_shuffled_objects_three_objects"
 "description": "A task requiring determining the final positions of a set of objects given their initial positions and a description of a sequence of swaps.\n\n"
-"doc_to_text": "Q: {{input}}\nA:"
+doc_to_text: "Q: {{input}}\n"
+gen_prefix: "A:"
 "include": "_zeroshot_template_yaml"
 "task": "bbh_zeroshot_tracking_shuffled_objects_three_objects"
 filter_list:

--- a/lm_eval/tasks/bbh/zeroshot/web_of_lies.yaml
+++ b/lm_eval/tasks/bbh/zeroshot/web_of_lies.yaml
@@ -1,6 +1,7 @@
 "dataset_name": "web_of_lies"
 "description": "Evaluate a random boolean function expressed as a word problem.\n\n"
-"doc_to_text": "Q: {{input}}\nA:"
+doc_to_text: "Q: {{input}}\n"
+gen_prefix: "A:"
 "include": "_zeroshot_template_yaml"
 "task": "bbh_zeroshot_web_of_lies"
 filter_list:

--- a/lm_eval/tasks/bbh/zeroshot/word_sorting.yaml
+++ b/lm_eval/tasks/bbh/zeroshot/word_sorting.yaml
@@ -1,6 +1,7 @@
 "dataset_name": "word_sorting"
 "description": "Sort a list of words.\n\n"
-"doc_to_text": "Q: {{input}}\nA:"
+doc_to_text: "Q: {{input}}\n"
+gen_prefix: "A:"
 "include": "_zeroshot_template_yaml"
 "task": "bbh_zeroshot_word_sorting"
 filter_list:


### PR DESCRIPTION
Fixing BBH benchmarks. It is crucial for this benchmark to use the --fewshot_as_multiturn if running with chat template
Additional changes
- CoT prompt moved the the assistant's response with the gen_prefix argument
- \n\n removed as a stop token due to some models (e.g. Qwen2.5) uses it to separate thinking steps and it resulted in premature termination