### PR TITLE
generative mmlu versions without system and without cot prompt

### DIFF
--- a/lm_eval/tasks/mmlu/flan_cot_zeroshot_nosystem/_mmlu.yaml
+++ b/lm_eval/tasks/mmlu/flan_cot_zeroshot_nosystem/_mmlu.yaml
@@ -1,0 +1,62 @@
+group: mmlu_flan_cot_zeroshot_nosystem
+group_alias: mmlu (flan style, zeroshot cot, no system)
+task:
+  - group: mmlu_flan_cot_zeroshot_nosystem_stem
+    task:
+      - mmlu_flan_cot_zeroshot_nosystem_stem
+    aggregate_metric_list:
+      - metric: exact_match
+        aggregation: mean
+        filter_list: strict-match
+        weight_by_size: True
+      - metric: exact_match
+        aggregation: mean
+        filter_list: flexible-extract
+        weight_by_size: True
+  - group: mmlu_flan_cot_zeroshot_nosystem_other
+    task:
+      - mmlu_flan_cot_zeroshot_nosystem_other
+    aggregate_metric_list:
+      - metric: exact_match
+        aggregation: mean
+        filter_list: strict-match
+        weight_by_size: True
+      - metric: exact_match
+        aggregation: mean
+        filter_list: flexible-extract
+        weight_by_size: True
+  - group: mmlu_flan_cot_zeroshot_nosystem_social_sciences
+    task:
+      - mmlu_flan_cot_zeroshot_nosystem_social_sciences
+    aggregate_metric_list:
+      - metric: exact_match
+        aggregation: mean
+        filter_list: strict-match
+        weight_by_size: True
+      - metric: exact_match
+        aggregation: mean
+        filter_list: flexible-extract
+        weight_by_size: True
+  - group: mmlu_flan_cot_zeroshot_nosystem_humanities
+    task:
+      - mmlu_flan_cot_zeroshot_nosystem_humanities
+    aggregate_metric_list:
+      - metric: exact_match
+        aggregation: mean
+        filter_list: strict-match
+        weight_by_size: True
+      - metric: exact_match
+        aggregation: mean
+        filter_list: flexible-extract
+        weight_by_size: True
+aggregate_metric_list:
+  - aggregation: mean
+    metric: exact_match
+    weight_by_size: True
+    filter_list: strict-match
+  - aggregation: mean
+    metric: exact_match
+    weight_by_size: True
+    filter_list: flexible-extract
+metadata:
+  version: 2

--- a/lm_eval/tasks/mmlu/flan_cot_zeroshot_nosystem/_mmlu_flan_cot_zeroshot_nosystem_template_yaml
+++ b/lm_eval/tasks/mmlu/flan_cot_zeroshot_nosystem/_mmlu_flan_cot_zeroshot_nosystem_template_yaml
@@ -2,7 +2,7 @@ dataset_path: hails/mmlu_no_train # a copy of `cais/mmlu` with no auxiliary_trai
 validation_split: validation
 fewshot_split: dev
 output_type: generate_until
-doc_to_text: "Q: {{question.strip()}}\n(A) {{choices[0]}} (B) {{choices[1]}} (C) {{choices[2]}} (D) {{choices[3]}}\nLet's think step by step."
+doc_to_text: "The following is a multiple choice question. Your response should be concise, and you should end with \"The answer is (X)\", where X is the correct letter choice.\n\nQ: {{question.strip()}}\n(A) {{choices[0]}} (B) {{choices[1]}} (C) {{choices[2]}} (D) {{choices[3]}}\nLet's think step by step."
 doc_to_target: "{{['(A)', '(B)', '(C)', '(D)'][answer]}}"
 filter_list:
   - name: "strict-match"

--- a/lm_eval/tasks/mmlu/flan_cot_zeroshot_nosystem/mmlu_abstract_algebra.yaml
+++ b/lm_eval/tasks/mmlu/flan_cot_zeroshot_nosystem/mmlu_abstract_algebra.yaml
@@ -1,0 +1,4 @@
+"dataset_name": "abstract_algebra"
+"tag": "mmlu_flan_cot_zeroshot_nosystem_stem"
+"include": "_mmlu_flan_cot_zeroshot_nosystem_template_yaml"
+"task": "mmlu_flan_cot_zeroshot_nosystem_abstract_algebra"

--- a/lm_eval/tasks/mmlu/flan_cot_zeroshot_nosystem/mmlu_anatomy.yaml
+++ b/lm_eval/tasks/mmlu/flan_cot_zeroshot_nosystem/mmlu_anatomy.yaml
@@ -1,0 +1,4 @@
+"dataset_name": "anatomy"
+"tag": "mmlu_flan_cot_zeroshot_nosystem_stem"
+"include": "_mmlu_flan_cot_zeroshot_nosystem_template_yaml"
+"task": "mmlu_flan_cot_zeroshot_nosystem_anatomy"

--- a/lm_eval/tasks/mmlu/flan_cot_zeroshot_nosystem/mmlu_astronomy.yaml
+++ b/lm_eval/tasks/mmlu/flan_cot_zeroshot_nosystem/mmlu_astronomy.yaml
@@ -1,0 +1,4 @@
+"dataset_name": "astronomy"
+"tag": "mmlu_flan_cot_zeroshot_nosystem_stem"
+"include": "_mmlu_flan_cot_zeroshot_nosystem_template_yaml"
+"task": "mmlu_flan_cot_zeroshot_nosystem_astronomy"

--- a/lm_eval/tasks/mmlu/flan_cot_zeroshot_nosystem/mmlu_business_ethics.yaml
+++ b/lm_eval/tasks/mmlu/flan_cot_zeroshot_nosystem/mmlu_business_ethics.yaml
@@ -1,0 +1,4 @@
+"dataset_name": "business_ethics"
+"tag": "mmlu_flan_cot_zeroshot_nosystem_other"
+"include": "_mmlu_flan_cot_zeroshot_nosystem_template_yaml"
+"task": "mmlu_flan_cot_zeroshot_nosystem_business_ethics"

--- a/lm_eval/tasks/mmlu/flan_cot_zeroshot_nosystem/mmlu_clinical_knowledge.yaml
+++ b/lm_eval/tasks/mmlu/flan_cot_zeroshot_nosystem/mmlu_clinical_knowledge.yaml
@@ -1,0 +1,4 @@
+"dataset_name": "clinical_knowledge"
+"tag": "mmlu_flan_cot_zeroshot_nosystem_other"
+"include": "_mmlu_flan_cot_zeroshot_nosystem_template_yaml"
+"task": "mmlu_flan_cot_zeroshot_nosystem_clinical_knowledge"

--- a/lm_eval/tasks/mmlu/flan_cot_zeroshot_nosystem/mmlu_college_biology.yaml
+++ b/lm_eval/tasks/mmlu/flan_cot_zeroshot_nosystem/mmlu_college_biology.yaml
@@ -1,0 +1,4 @@
+"dataset_name": "college_biology"
+"tag": "mmlu_flan_cot_zeroshot_nosystem_stem"
+"include": "_mmlu_flan_cot_zeroshot_nosystem_template_yaml"
+"task": "mmlu_flan_cot_zeroshot_nosystem_college_biology"

--- a/lm_eval/tasks/mmlu/flan_cot_zeroshot_nosystem/mmlu_college_chemistry.yaml
+++ b/lm_eval/tasks/mmlu/flan_cot_zeroshot_nosystem/mmlu_college_chemistry.yaml
@@ -1,0 +1,4 @@
+"dataset_name": "college_chemistry"
+"tag": "mmlu_flan_cot_zeroshot_nosystem_stem"
+"include": "_mmlu_flan_cot_zeroshot_nosystem_template_yaml"
+"task": "mmlu_flan_cot_zeroshot_nosystem_college_chemistry"

--- a/lm_eval/tasks/mmlu/flan_cot_zeroshot_nosystem/mmlu_college_computer_science.yaml
+++ b/lm_eval/tasks/mmlu/flan_cot_zeroshot_nosystem/mmlu_college_computer_science.yaml
@@ -1,0 +1,4 @@
+"dataset_name": "college_computer_science"
+"tag": "mmlu_flan_cot_zeroshot_nosystem_stem"
+"include": "_mmlu_flan_cot_zeroshot_nosystem_template_yaml"
+"task": "mmlu_flan_cot_zeroshot_nosystem_college_computer_science"

--- a/lm_eval/tasks/mmlu/flan_cot_zeroshot_nosystem/mmlu_college_mathematics.yaml
+++ b/lm_eval/tasks/mmlu/flan_cot_zeroshot_nosystem/mmlu_college_mathematics.yaml
@@ -1,0 +1,4 @@
+"dataset_name": "college_mathematics"
+"tag": "mmlu_flan_cot_zeroshot_nosystem_stem"
+"include": "_mmlu_flan_cot_zeroshot_nosystem_template_yaml"
+"task": "mmlu_flan_cot_zeroshot_nosystem_college_mathematics"

--- a/lm_eval/tasks/mmlu/flan_cot_zeroshot_nosystem/mmlu_college_medicine.yaml
+++ b/lm_eval/tasks/mmlu/flan_cot_zeroshot_nosystem/mmlu_college_medicine.yaml
@@ -1,0 +1,4 @@
+"dataset_name": "college_medicine"
+"tag": "mmlu_flan_cot_zeroshot_nosystem_other"
+"include": "_mmlu_flan_cot_zeroshot_nosystem_template_yaml"
+"task": "mmlu_flan_cot_zeroshot_nosystem_college_medicine"

--- a/lm_eval/tasks/mmlu/flan_cot_zeroshot_nosystem/mmlu_college_physics.yaml
+++ b/lm_eval/tasks/mmlu/flan_cot_zeroshot_nosystem/mmlu_college_physics.yaml
@@ -1,0 +1,4 @@
+"dataset_name": "college_physics"
+"tag": "mmlu_flan_cot_zeroshot_nosystem_stem"
+"include": "_mmlu_flan_cot_zeroshot_nosystem_template_yaml"
+"task": "mmlu_flan_cot_zeroshot_nosystem_college_physics"

--- a/lm_eval/tasks/mmlu/flan_cot_zeroshot_nosystem/mmlu_computer_security.yaml
+++ b/lm_eval/tasks/mmlu/flan_cot_zeroshot_nosystem/mmlu_computer_security.yaml
@@ -1,0 +1,4 @@
+"dataset_name": "computer_security"
+"tag": "mmlu_flan_cot_zeroshot_nosystem_stem"
+"include": "_mmlu_flan_cot_zeroshot_nosystem_template_yaml"
+"task": "mmlu_flan_cot_zeroshot_nosystem_computer_security"

--- a/lm_eval/tasks/mmlu/flan_cot_zeroshot_nosystem/mmlu_conceptual_physics.yaml
+++ b/lm_eval/tasks/mmlu/flan_cot_zeroshot_nosystem/mmlu_conceptual_physics.yaml
@@ -1,0 +1,4 @@
+"dataset_name": "conceptual_physics"
+"tag": "mmlu_flan_cot_zeroshot_nosystem_stem"
+"include": "_mmlu_flan_cot_zeroshot_nosystem_template_yaml"
+"task": "mmlu_flan_cot_zeroshot_nosystem_conceptual_physics"

--- a/lm_eval/tasks/mmlu/flan_cot_zeroshot_nosystem/mmlu_econometrics.yaml
+++ b/lm_eval/tasks/mmlu/flan_cot_zeroshot_nosystem/mmlu_econometrics.yaml
@@ -1,0 +1,4 @@
+"dataset_name": "econometrics"
+"tag": "mmlu_flan_cot_zeroshot_nosystem_social_sciences"
+"include": "_mmlu_flan_cot_zeroshot_nosystem_template_yaml"
+"task": "mmlu_flan_cot_zeroshot_nosystem_econometrics"

--- a/lm_eval/tasks/mmlu/flan_cot_zeroshot_nosystem/mmlu_electrical_engineering.yaml
+++ b/lm_eval/tasks/mmlu/flan_cot_zeroshot_nosystem/mmlu_electrical_engineering.yaml
@@ -1,0 +1,4 @@
+"dataset_name": "electrical_engineering"
+"tag": "mmlu_flan_cot_zeroshot_nosystem_stem"
+"include": "_mmlu_flan_cot_zeroshot_nosystem_template_yaml"
+"task": "mmlu_flan_cot_zeroshot_nosystem_electrical_engineering"

--- a/lm_eval/tasks/mmlu/flan_cot_zeroshot_nosystem/mmlu_elementary_mathematics.yaml
+++ b/lm_eval/tasks/mmlu/flan_cot_zeroshot_nosystem/mmlu_elementary_mathematics.yaml
@@ -1,0 +1,4 @@
+"dataset_name": "elementary_mathematics"
+"tag": "mmlu_flan_cot_zeroshot_nosystem_stem"
+"include": "_mmlu_flan_cot_zeroshot_nosystem_template_yaml"
+"task": "mmlu_flan_cot_zeroshot_nosystem_elementary_mathematics"

--- a/lm_eval/tasks/mmlu/flan_cot_zeroshot_nosystem/mmlu_formal_logic.yaml
+++ b/lm_eval/tasks/mmlu/flan_cot_zeroshot_nosystem/mmlu_formal_logic.yaml
@@ -1,0 +1,4 @@
+"dataset_name": "formal_logic"
+"tag": "mmlu_flan_cot_zeroshot_nosystem_humanities"
+"include": "_mmlu_flan_cot_zeroshot_nosystem_template_yaml"
+"task": "mmlu_flan_cot_zeroshot_nosystem_formal_logic"

--- a/lm_eval/tasks/mmlu/flan_cot_zeroshot_nosystem/mmlu_global_facts.yaml
+++ b/lm_eval/tasks/mmlu/flan_cot_zeroshot_nosystem/mmlu_global_facts.yaml
@@ -1,0 +1,4 @@
+"dataset_name": "global_facts"
+"tag": "mmlu_flan_cot_zeroshot_nosystem_other"
+"include": "_mmlu_flan_cot_zeroshot_nosystem_template_yaml"
+"task": "mmlu_flan_cot_zeroshot_nosystem_global_facts"

--- a/lm_eval/tasks/mmlu/flan_cot_zeroshot_nosystem/mmlu_high_school_biology.yaml
+++ b/lm_eval/tasks/mmlu/flan_cot_zeroshot_nosystem/mmlu_high_school_biology.yaml
@@ -1,0 +1,4 @@
+"dataset_name": "high_school_biology"
+"tag": "mmlu_flan_cot_zeroshot_nosystem_stem"
+"include": "_mmlu_flan_cot_zeroshot_nosystem_template_yaml"
+"task": "mmlu_flan_cot_zeroshot_nosystem_high_school_biology"

--- a/lm_eval/tasks/mmlu/flan_cot_zeroshot_nosystem/mmlu_high_school_chemistry.yaml
+++ b/lm_eval/tasks/mmlu/flan_cot_zeroshot_nosystem/mmlu_high_school_chemistry.yaml
@@ -1,0 +1,4 @@
+"dataset_name": "high_school_chemistry"
+"tag": "mmlu_flan_cot_zeroshot_nosystem_stem"
+"include": "_mmlu_flan_cot_zeroshot_nosystem_template_yaml"
+"task": "mmlu_flan_cot_zeroshot_nosystem_high_school_chemistry"

--- a/lm_eval/tasks/mmlu/flan_cot_zeroshot_nosystem/mmlu_high_school_computer_science.yaml
+++ b/lm_eval/tasks/mmlu/flan_cot_zeroshot_nosystem/mmlu_high_school_computer_science.yaml
@@ -1,0 +1,4 @@
+"dataset_name": "high_school_computer_science"
+"tag": "mmlu_flan_cot_zeroshot_nosystem_stem"
+"include": "_mmlu_flan_cot_zeroshot_nosystem_template_yaml"
+"task": "mmlu_flan_cot_zeroshot_nosystem_high_school_computer_science"

--- a/lm_eval/tasks/mmlu/flan_cot_zeroshot_nosystem/mmlu_high_school_european_history.yaml
+++ b/lm_eval/tasks/mmlu/flan_cot_zeroshot_nosystem/mmlu_high_school_european_history.yaml
@@ -1,0 +1,4 @@
+"dataset_name": "high_school_european_history"
+"tag": "mmlu_flan_cot_zeroshot_nosystem_humanities"
+"include": "_mmlu_flan_cot_zeroshot_nosystem_template_yaml"
+"task": "mmlu_flan_cot_zeroshot_nosystem_high_school_european_history"

--- a/lm_eval/tasks/mmlu/flan_cot_zeroshot_nosystem/mmlu_high_school_geography.yaml
+++ b/lm_eval/tasks/mmlu/flan_cot_zeroshot_nosystem/mmlu_high_school_geography.yaml
@@ -1,0 +1,4 @@
+"dataset_name": "high_school_geography"
+"tag": "mmlu_flan_cot_zeroshot_nosystem_social_sciences"
+"include": "_mmlu_flan_cot_zeroshot_nosystem_template_yaml"
+"task": "mmlu_flan_cot_zeroshot_nosystem_high_school_geography"

--- a/lm_eval/tasks/mmlu/flan_cot_zeroshot_nosystem/mmlu_high_school_government_and_politics.yaml
+++ b/lm_eval/tasks/mmlu/flan_cot_zeroshot_nosystem/mmlu_high_school_government_and_politics.yaml
@@ -1,0 +1,4 @@
+"dataset_name": "high_school_government_and_politics"
+"tag": "mmlu_flan_cot_zeroshot_nosystem_social_sciences"
+"include": "_mmlu_flan_cot_zeroshot_nosystem_template_yaml"
+"task": "mmlu_flan_cot_zeroshot_nosystem_high_school_government_and_politics"

--- a/lm_eval/tasks/mmlu/flan_cot_zeroshot_nosystem/mmlu_high_school_macroeconomics.yaml
+++ b/lm_eval/tasks/mmlu/flan_cot_zeroshot_nosystem/mmlu_high_school_macroeconomics.yaml
@@ -1,0 +1,4 @@
+"dataset_name": "high_school_macroeconomics"
+"tag": "mmlu_flan_cot_zeroshot_nosystem_social_sciences"
+"include": "_mmlu_flan_cot_zeroshot_nosystem_template_yaml"
+"task": "mmlu_flan_cot_zeroshot_nosystem_high_school_macroeconomics"

--- a/lm_eval/tasks/mmlu/flan_cot_zeroshot_nosystem/mmlu_high_school_mathematics.yaml
+++ b/lm_eval/tasks/mmlu/flan_cot_zeroshot_nosystem/mmlu_high_school_mathematics.yaml
@@ -1,0 +1,4 @@
+"dataset_name": "high_school_mathematics"
+"tag": "mmlu_flan_cot_zeroshot_nosystem_stem"
+"include": "_mmlu_flan_cot_zeroshot_nosystem_template_yaml"
+"task": "mmlu_flan_cot_zeroshot_nosystem_high_school_mathematics"

--- a/lm_eval/tasks/mmlu/flan_cot_zeroshot_nosystem/mmlu_high_school_microeconomics.yaml
+++ b/lm_eval/tasks/mmlu/flan_cot_zeroshot_nosystem/mmlu_high_school_microeconomics.yaml
@@ -1,0 +1,4 @@
+"dataset_name": "high_school_microeconomics"
+"tag": "mmlu_flan_cot_zeroshot_nosystem_social_sciences"
+"include": "_mmlu_flan_cot_zeroshot_nosystem_template_yaml"
+"task": "mmlu_flan_cot_zeroshot_nosystem_high_school_microeconomics"

--- a/lm_eval/tasks/mmlu/flan_cot_zeroshot_nosystem/mmlu_high_school_physics.yaml
+++ b/lm_eval/tasks/mmlu/flan_cot_zeroshot_nosystem/mmlu_high_school_physics.yaml
@@ -1,0 +1,4 @@
+"dataset_name": "high_school_physics"
+"tag": "mmlu_flan_cot_zeroshot_nosystem_stem"
+"include": "_mmlu_flan_cot_zeroshot_nosystem_template_yaml"
+"task": "mmlu_flan_cot_zeroshot_nosystem_high_school_physics"

--- a/lm_eval/tasks/mmlu/flan_cot_zeroshot_nosystem/mmlu_high_school_psychology.yaml
+++ b/lm_eval/tasks/mmlu/flan_cot_zeroshot_nosystem/mmlu_high_school_psychology.yaml
@@ -1,0 +1,4 @@
+"dataset_name": "high_school_psychology"
+"tag": "mmlu_flan_cot_zeroshot_nosystem_social_sciences"
+"include": "_mmlu_flan_cot_zeroshot_nosystem_template_yaml"
+"task": "mmlu_flan_cot_zeroshot_nosystem_high_school_psychology"

--- a/lm_eval/tasks/mmlu/flan_cot_zeroshot_nosystem/mmlu_high_school_statistics.yaml
+++ b/lm_eval/tasks/mmlu/flan_cot_zeroshot_nosystem/mmlu_high_school_statistics.yaml
@@ -1,0 +1,4 @@
+"dataset_name": "high_school_statistics"
+"tag": "mmlu_flan_cot_zeroshot_nosystem_stem"
+"include": "_mmlu_flan_cot_zeroshot_nosystem_template_yaml"
+"task": "mmlu_flan_cot_zeroshot_nosystem_high_school_statistics"

--- a/lm_eval/tasks/mmlu/flan_cot_zeroshot_nosystem/mmlu_high_school_us_history.yaml
+++ b/lm_eval/tasks/mmlu/flan_cot_zeroshot_nosystem/mmlu_high_school_us_history.yaml
@@ -1,0 +1,4 @@
+"dataset_name": "high_school_us_history"
+"tag": "mmlu_flan_cot_zeroshot_nosystem_humanities"
+"include": "_mmlu_flan_cot_zeroshot_nosystem_template_yaml"
+"task": "mmlu_flan_cot_zeroshot_nosystem_high_school_us_history"

--- a/lm_eval/tasks/mmlu/flan_cot_zeroshot_nosystem/mmlu_high_school_world_history.yaml
+++ b/lm_eval/tasks/mmlu/flan_cot_zeroshot_nosystem/mmlu_high_school_world_history.yaml
@@ -1,0 +1,4 @@
+"dataset_name": "high_school_world_history"
+"tag": "mmlu_flan_cot_zeroshot_nosystem_humanities"
+"include": "_mmlu_flan_cot_zeroshot_nosystem_template_yaml"
+"task": "mmlu_flan_cot_zeroshot_nosystem_high_school_world_history"

--- a/lm_eval/tasks/mmlu/flan_cot_zeroshot_nosystem/mmlu_human_aging.yaml
+++ b/lm_eval/tasks/mmlu/flan_cot_zeroshot_nosystem/mmlu_human_aging.yaml
@@ -1,0 +1,4 @@
+"dataset_name": "human_aging"
+"tag": "mmlu_flan_cot_zeroshot_nosystem_other"
+"include": "_mmlu_flan_cot_zeroshot_nosystem_template_yaml"
+"task": "mmlu_flan_cot_zeroshot_nosystem_human_aging"

--- a/lm_eval/tasks/mmlu/flan_cot_zeroshot_nosystem/mmlu_human_sexuality.yaml
+++ b/lm_eval/tasks/mmlu/flan_cot_zeroshot_nosystem/mmlu_human_sexuality.yaml
@@ -1,0 +1,4 @@
+"dataset_name": "human_sexuality"
+"tag": "mmlu_flan_cot_zeroshot_nosystem_social_sciences"
+"include": "_mmlu_flan_cot_zeroshot_nosystem_template_yaml"
+"task": "mmlu_flan_cot_zeroshot_nosystem_human_sexuality"

--- a/lm_eval/tasks/mmlu/flan_cot_zeroshot_nosystem/mmlu_international_law.yaml
+++ b/lm_eval/tasks/mmlu/flan_cot_zeroshot_nosystem/mmlu_international_law.yaml
@@ -1,0 +1,4 @@
+"dataset_name": "international_law"
+"tag": "mmlu_flan_cot_zeroshot_nosystem_humanities"
+"include": "_mmlu_flan_cot_zeroshot_nosystem_template_yaml"
+"task": "mmlu_flan_cot_zeroshot_nosystem_international_law"

--- a/lm_eval/tasks/mmlu/flan_cot_zeroshot_nosystem/mmlu_jurisprudence.yaml
+++ b/lm_eval/tasks/mmlu/flan_cot_zeroshot_nosystem/mmlu_jurisprudence.yaml
@@ -1,0 +1,4 @@
+"dataset_name": "jurisprudence"
+"tag": "mmlu_flan_cot_zeroshot_nosystem_humanities"
+"include": "_mmlu_flan_cot_zeroshot_nosystem_template_yaml"
+"task": "mmlu_flan_cot_zeroshot_nosystem_jurisprudence"

--- a/lm_eval/tasks/mmlu/flan_cot_zeroshot_nosystem/mmlu_logical_fallacies.yaml
+++ b/lm_eval/tasks/mmlu/flan_cot_zeroshot_nosystem/mmlu_logical_fallacies.yaml
@@ -1,0 +1,4 @@
+"dataset_name": "logical_fallacies"
+"tag": "mmlu_flan_cot_zeroshot_nosystem_humanities"
+"include": "_mmlu_flan_cot_zeroshot_nosystem_template_yaml"
+"task": "mmlu_flan_cot_zeroshot_nosystem_logical_fallacies"

--- a/lm_eval/tasks/mmlu/flan_cot_zeroshot_nosystem/mmlu_machine_learning.yaml
+++ b/lm_eval/tasks/mmlu/flan_cot_zeroshot_nosystem/mmlu_machine_learning.yaml
@@ -1,0 +1,4 @@
+"dataset_name": "machine_learning"
+"tag": "mmlu_flan_cot_zeroshot_nosystem_stem"
+"include": "_mmlu_flan_cot_zeroshot_nosystem_template_yaml"
+"task": "mmlu_flan_cot_zeroshot_nosystem_machine_learning"

--- a/lm_eval/tasks/mmlu/flan_cot_zeroshot_nosystem/mmlu_management.yaml
+++ b/lm_eval/tasks/mmlu/flan_cot_zeroshot_nosystem/mmlu_management.yaml
@@ -1,0 +1,4 @@
+"dataset_name": "management"
+"tag": "mmlu_flan_cot_zeroshot_nosystem_other"
+"include": "_mmlu_flan_cot_zeroshot_nosystem_template_yaml"
+"task": "mmlu_flan_cot_zeroshot_nosystem_management"

--- a/lm_eval/tasks/mmlu/flan_cot_zeroshot_nosystem/mmlu_marketing.yaml
+++ b/lm_eval/tasks/mmlu/flan_cot_zeroshot_nosystem/mmlu_marketing.yaml
@@ -1,0 +1,4 @@
+"dataset_name": "marketing"
+"tag": "mmlu_flan_cot_zeroshot_nosystem_other"
+"include": "_mmlu_flan_cot_zeroshot_nosystem_template_yaml"
+"task": "mmlu_flan_cot_zeroshot_nosystem_marketing"

--- a/lm_eval/tasks/mmlu/flan_cot_zeroshot_nosystem/mmlu_medical_genetics.yaml
+++ b/lm_eval/tasks/mmlu/flan_cot_zeroshot_nosystem/mmlu_medical_genetics.yaml
@@ -1,0 +1,4 @@
+"dataset_name": "medical_genetics"
+"tag": "mmlu_flan_cot_zeroshot_nosystem_other"
+"include": "_mmlu_flan_cot_zeroshot_nosystem_template_yaml"
+"task": "mmlu_flan_cot_zeroshot_nosystem_medical_genetics"

--- a/lm_eval/tasks/mmlu/flan_cot_zeroshot_nosystem/mmlu_miscellaneous.yaml
+++ b/lm_eval/tasks/mmlu/flan_cot_zeroshot_nosystem/mmlu_miscellaneous.yaml
@@ -1,0 +1,4 @@
+"dataset_name": "miscellaneous"
+"tag": "mmlu_flan_cot_zeroshot_nosystem_other"
+"include": "_mmlu_flan_cot_zeroshot_nosystem_template_yaml"
+"task": "mmlu_flan_cot_zeroshot_nosystem_miscellaneous"

--- a/lm_eval/tasks/mmlu/flan_cot_zeroshot_nosystem/mmlu_moral_disputes.yaml
+++ b/lm_eval/tasks/mmlu/flan_cot_zeroshot_nosystem/mmlu_moral_disputes.yaml
@@ -1,0 +1,4 @@
+"dataset_name": "moral_disputes"
+"tag": "mmlu_flan_cot_zeroshot_nosystem_humanities"
+"include": "_mmlu_flan_cot_zeroshot_nosystem_template_yaml"
+"task": "mmlu_flan_cot_zeroshot_nosystem_moral_disputes"

--- a/lm_eval/tasks/mmlu/flan_cot_zeroshot_nosystem/mmlu_moral_scenarios.yaml
+++ b/lm_eval/tasks/mmlu/flan_cot_zeroshot_nosystem/mmlu_moral_scenarios.yaml
@@ -1,0 +1,4 @@
+"dataset_name": "moral_scenarios"
+"tag": "mmlu_flan_cot_zeroshot_nosystem_humanities"
+"include": "_mmlu_flan_cot_zeroshot_nosystem_template_yaml"
+"task": "mmlu_flan_cot_zeroshot_nosystem_moral_scenarios"

--- a/lm_eval/tasks/mmlu/flan_cot_zeroshot_nosystem/mmlu_nutrition.yaml
+++ b/lm_eval/tasks/mmlu/flan_cot_zeroshot_nosystem/mmlu_nutrition.yaml
@@ -1,0 +1,4 @@
+"dataset_name": "nutrition"
+"tag": "mmlu_flan_cot_zeroshot_nosystem_other"
+"include": "_mmlu_flan_cot_zeroshot_nosystem_template_yaml"
+"task": "mmlu_flan_cot_zeroshot_nosystem_nutrition"

--- a/lm_eval/tasks/mmlu/flan_cot_zeroshot_nosystem/mmlu_philosophy.yaml
+++ b/lm_eval/tasks/mmlu/flan_cot_zeroshot_nosystem/mmlu_philosophy.yaml
@@ -1,0 +1,4 @@
+"dataset_name": "philosophy"
+"tag": "mmlu_flan_cot_zeroshot_nosystem_humanities"
+"include": "_mmlu_flan_cot_zeroshot_nosystem_template_yaml"
+"task": "mmlu_flan_cot_zeroshot_nosystem_philosophy"

--- a/lm_eval/tasks/mmlu/flan_cot_zeroshot_nosystem/mmlu_prehistory.yaml
+++ b/lm_eval/tasks/mmlu/flan_cot_zeroshot_nosystem/mmlu_prehistory.yaml
@@ -1,0 +1,4 @@
+"dataset_name": "prehistory"
+"tag": "mmlu_flan_cot_zeroshot_nosystem_humanities"
+"include": "_mmlu_flan_cot_zeroshot_nosystem_template_yaml"
+"task": "mmlu_flan_cot_zeroshot_nosystem_prehistory"

--- a/lm_eval/tasks/mmlu/flan_cot_zeroshot_nosystem/mmlu_professional_accounting.yaml
+++ b/lm_eval/tasks/mmlu/flan_cot_zeroshot_nosystem/mmlu_professional_accounting.yaml
@@ -1,0 +1,4 @@
+"dataset_name": "professional_accounting"
+"tag": "mmlu_flan_cot_zeroshot_nosystem_other"
+"include": "_mmlu_flan_cot_zeroshot_nosystem_template_yaml"
+"task": "mmlu_flan_cot_zeroshot_nosystem_professional_accounting"

--- a/lm_eval/tasks/mmlu/flan_cot_zeroshot_nosystem/mmlu_professional_law.yaml
+++ b/lm_eval/tasks/mmlu/flan_cot_zeroshot_nosystem/mmlu_professional_law.yaml
@@ -1,0 +1,4 @@
+"dataset_name": "professional_law"
+"tag": "mmlu_flan_cot_zeroshot_nosystem_humanities"
+"include": "_mmlu_flan_cot_zeroshot_nosystem_template_yaml"
+"task": "mmlu_flan_cot_zeroshot_nosystem_professional_law"

--- a/lm_eval/tasks/mmlu/flan_cot_zeroshot_nosystem/mmlu_professional_medicine.yaml
+++ b/lm_eval/tasks/mmlu/flan_cot_zeroshot_nosystem/mmlu_professional_medicine.yaml
@@ -1,0 +1,4 @@
+"dataset_name": "professional_medicine"
+"tag": "mmlu_flan_cot_zeroshot_nosystem_other"
+"include": "_mmlu_flan_cot_zeroshot_nosystem_template_yaml"
+"task": "mmlu_flan_cot_zeroshot_nosystem_professional_medicine"

--- a/lm_eval/tasks/mmlu/flan_cot_zeroshot_nosystem/mmlu_professional_psychology.yaml
+++ b/lm_eval/tasks/mmlu/flan_cot_zeroshot_nosystem/mmlu_professional_psychology.yaml
@@ -1,0 +1,4 @@
+"dataset_name": "professional_psychology"
+"tag": "mmlu_flan_cot_zeroshot_nosystem_social_sciences"
+"include": "_mmlu_flan_cot_zeroshot_nosystem_template_yaml"
+"task": "mmlu_flan_cot_zeroshot_nosystem_professional_psychology"

--- a/lm_eval/tasks/mmlu/flan_cot_zeroshot_nosystem/mmlu_public_relations.yaml
+++ b/lm_eval/tasks/mmlu/flan_cot_zeroshot_nosystem/mmlu_public_relations.yaml
@@ -1,0 +1,4 @@
+"dataset_name": "public_relations"
+"tag": "mmlu_flan_cot_zeroshot_nosystem_social_sciences"
+"include": "_mmlu_flan_cot_zeroshot_nosystem_template_yaml"
+"task": "mmlu_flan_cot_zeroshot_nosystem_public_relations"

--- a/lm_eval/tasks/mmlu/flan_cot_zeroshot_nosystem/mmlu_security_studies.yaml
+++ b/lm_eval/tasks/mmlu/flan_cot_zeroshot_nosystem/mmlu_security_studies.yaml
@@ -1,0 +1,4 @@
+"dataset_name": "security_studies"
+"tag": "mmlu_flan_cot_zeroshot_nosystem_social_sciences"
+"include": "_mmlu_flan_cot_zeroshot_nosystem_template_yaml"
+"task": "mmlu_flan_cot_zeroshot_nosystem_security_studies"

--- a/lm_eval/tasks/mmlu/flan_cot_zeroshot_nosystem/mmlu_sociology.yaml
+++ b/lm_eval/tasks/mmlu/flan_cot_zeroshot_nosystem/mmlu_sociology.yaml
@@ -1,0 +1,4 @@
+"dataset_name": "sociology"
+"tag": "mmlu_flan_cot_zeroshot_nosystem_social_sciences"
+"include": "_mmlu_flan_cot_zeroshot_nosystem_template_yaml"
+"task": "mmlu_flan_cot_zeroshot_nosystem_sociology"

--- a/lm_eval/tasks/mmlu/flan_cot_zeroshot_nosystem/mmlu_us_foreign_policy.yaml
+++ b/lm_eval/tasks/mmlu/flan_cot_zeroshot_nosystem/mmlu_us_foreign_policy.yaml
@@ -1,0 +1,4 @@
+"dataset_name": "us_foreign_policy"
+"tag": "mmlu_flan_cot_zeroshot_nosystem_social_sciences"
+"include": "_mmlu_flan_cot_zeroshot_nosystem_template_yaml"
+"task": "mmlu_flan_cot_zeroshot_nosystem_us_foreign_policy"

--- a/lm_eval/tasks/mmlu/flan_cot_zeroshot_nosystem/mmlu_virology.yaml
+++ b/lm_eval/tasks/mmlu/flan_cot_zeroshot_nosystem/mmlu_virology.yaml
@@ -1,0 +1,4 @@
+"dataset_name": "virology"
+"tag": "mmlu_flan_cot_zeroshot_nosystem_other"
+"include": "_mmlu_flan_cot_zeroshot_nosystem_template_yaml"
+"task": "mmlu_flan_cot_zeroshot_nosystem_virology"

--- a/lm_eval/tasks/mmlu/flan_cot_zeroshot_nosystem/mmlu_world_religions.yaml
+++ b/lm_eval/tasks/mmlu/flan_cot_zeroshot_nosystem/mmlu_world_religions.yaml
@@ -1,0 +1,4 @@
+"dataset_name": "world_religions"
+"tag": "mmlu_flan_cot_zeroshot_nosystem_humanities"
+"include": "_mmlu_flan_cot_zeroshot_nosystem_template_yaml"
+"task": "mmlu_flan_cot_zeroshot_nosystem_world_religions"

--- a/lm_eval/tasks/mmlu/flan_cot_zeroshot_nosystem/utils.py
+++ b/lm_eval/tasks/mmlu/flan_cot_zeroshot_nosystem/utils.py
@@ -1,0 +1,112 @@
+import re
+import sys
+import unicodedata
+
+from lm_eval.filters.extraction import RegexFilter
+
+
+class MultiChoiceRegexFilter(RegexFilter):
+    """ """
+
+    def __init__(
+        self,
+        regex_pattern: str = r"#### (\-?[0-9\.\,]+)",
+        group_select=0,
+        fallback: str = "[invalid]",
+        ignore_case=False,
+        ignore_punctuation=False,
+        regexes_to_ignore=None,
+    ) -> None:
+        """
+        regex_pattern: The basic regex pattern to use. If fails to match, we will use the customized match procedure
+                        - step 1 : We parse the choices between ([A-Z])s then try to find these choices in the response.
+                        - step 2 : We parse the choice with regex :[\s]*([A-?]), where ? varies by number of choices.
+        group_select: Selects the (group_select)th match from the findall result.
+        ignore_case: Ignores the case during step 1 matching
+        ignore_punctuation: Remove the punctuation during step 1 matching
+        regexes_to_ignore: Remove these regexes during step 1 matching
+        """
+        super().__init__(regex_pattern, group_select, fallback)
+        self.ignore_case = ignore_case
+        self.ignore_punctuation = ignore_punctuation
+        self.regexes_to_ignore = regexes_to_ignore
+
+    def apply(self, resps, docs):
+        # here, we assume we have a list, in which each element is
+        # a list of model responses for some particular input/target pair.
+        # so we process each of these (same input/target response sets)
+        # independently (and keep them a list.)
+
+        def find_match(regex, resp, convert_dict={}):
+            match = regex.findall(resp)
+            if match:
+                match = match[self.group_select]
+                if isinstance(match, tuple):
+                    match = [m for m in match if m][0]
+                match = match.strip()
+                if match and match in convert_dict:
+                    match = convert_dict[match]
+            return match
+
+        punct_tbl = dict.fromkeys(
+            i
+            for i in range(sys.maxunicode)
+            if unicodedata.category(chr(i)).startswith("P")
+        )
+
+        def filter_ignores(st):
+            if self.regexes_to_ignore is not None:
+                for s in self.regexes_to_ignore:
+                    st = re.sub(s, "", st)
+
+            if self.ignore_case:
+                st = st.lower()
+
+            if self.ignore_punctuation:
+                # https://stackoverflow.com/a/266162
+                st = st.translate(punct_tbl)
+            return st
+
+        filtered_resps = []
+
+        for r, doc in zip(resps, docs):
+            fallback_regexes = []
+            choice_to_alpha = {}
+            next_alpha = "A"
+
+            without_paren_fallback_regexes = []
+            without_paren_to_target = {}
+
+            choices = doc["choices"]
+            for c in choices:
+                m = filter_ignores(c.strip())
+                fallback_regexes.append(f"{re.escape(m)}")
+                choice_to_alpha[m] = f"({next_alpha})"
+
+                without_paren_fallback_regexes.append(next_alpha)
+                without_paren_to_target[next_alpha] = f"({next_alpha})"
+
+                next_alpha = chr(ord(next_alpha) + 1)
+            fallback_regex = re.compile("|".join(fallback_regexes))
+            without_paren_fallback_regex = "|".join(without_paren_fallback_regexes)
+            without_paren_fallback_regex = re.compile(
+                f":[\s]*({without_paren_fallback_regex})"
+            )
+
+            filtered = []
+            for resp in r:
+                match = find_match(self.regex, resp)
+                if not match:
+                    match = find_match(
+                        fallback_regex, filter_ignores(resp), choice_to_alpha
+                    )
+                    if not match:
+                        match = find_match(
+                            without_paren_fallback_regex, resp, without_paren_to_target
+                        )
+                if not match:
+                    match = self.fallback
+                filtered.append(match)
+            filtered_resps.append(filtered)
+
+        return filtered_resps

--- a/lm_eval/tasks/mmlu/flan_no_cot_zeroshot/_mmlu.yaml
+++ b/lm_eval/tasks/mmlu/flan_no_cot_zeroshot/_mmlu.yaml
@@ -1,0 +1,62 @@
+group: mmlu_flan_no_cot_zeroshot
+group_alias: mmlu (flan style, zeroshot no cot)
+task:
+  - group: mmlu_flan_no_cot_zeroshot_stem
+    task:
+      - mmlu_flan_no_cot_zeroshot_stem
+    aggregate_metric_list:
+      - metric: exact_match
+        aggregation: mean
+        filter_list: strict-match
+        weight_by_size: True
+      - metric: exact_match
+        aggregation: mean
+        filter_list: flexible-extract
+        weight_by_size: True
+  - group: mmlu_flan_no_cot_zeroshot_other
+    task:
+      - mmlu_flan_no_cot_zeroshot_other
+    aggregate_metric_list:
+      - metric: exact_match
+        aggregation: mean
+        filter_list: strict-match
+        weight_by_size: True
+      - metric: exact_match
+        aggregation: mean
+        filter_list: flexible-extract
+        weight_by_size: True
+  - group: mmlu_flan_no_cot_zeroshot_social_sciences
+    task:
+      - mmlu_flan_no_cot_zeroshot_social_sciences
+    aggregate_metric_list:
+      - metric: exact_match
+        aggregation: mean
+        filter_list: strict-match
+        weight_by_size: True
+      - metric: exact_match
+        aggregation: mean
+        filter_list: flexible-extract
+        weight_by_size: True
+  - group: mmlu_flan_no_cot_zeroshot_humanities
+    task:
+      - mmlu_flan_no_cot_zeroshot_humanities
+    aggregate_metric_list:
+      - metric: exact_match
+        aggregation: mean
+        filter_list: strict-match
+        weight_by_size: True
+      - metric: exact_match
+        aggregation: mean
+        filter_list: flexible-extract
+        weight_by_size: True
+aggregate_metric_list:
+  - aggregation: mean
+    metric: exact_match
+    weight_by_size: True
+    filter_list: strict-match
+  - aggregation: mean
+    metric: exact_match
+    weight_by_size: True
+    filter_list: flexible-extract
+metadata:
+  version: 2

--- a/lm_eval/tasks/mmlu/flan_no_cot_zeroshot/_mmlu_flan_no_cot_zeroshot_template_yaml
+++ b/lm_eval/tasks/mmlu/flan_no_cot_zeroshot/_mmlu_flan_no_cot_zeroshot_template_yaml
@@ -2,7 +2,7 @@ dataset_path: hails/mmlu_no_train # a copy of `cais/mmlu` with no auxiliary_trai
 validation_split: validation
 fewshot_split: dev
 output_type: generate_until
-doc_to_text: "Q: {{question.strip()}}\n(A) {{choices[0]}} (B) {{choices[1]}} (C) {{choices[2]}} (D) {{choices[3]}}\nLet's think step by step."
+doc_to_text: "Q: {{question.strip()}}\n(A) {{choices[0]}} (B) {{choices[1]}} (C) {{choices[2]}} (D) {{choices[3]}}."
 doc_to_target: "{{['(A)', '(B)', '(C)', '(D)'][answer]}}"
 filter_list:
   - name: "strict-match"

--- a/lm_eval/tasks/mmlu/flan_no_cot_zeroshot/mmlu_abstract_algebra.yaml
+++ b/lm_eval/tasks/mmlu/flan_no_cot_zeroshot/mmlu_abstract_algebra.yaml
@@ -1,0 +1,6 @@
+"dataset_name": "abstract_algebra"
+"description": "The following are multiple choice questions (with answers) about abstract\
+  \ algebra. Your response should be concise, and you should end with \"The answer is (X)\", where X is the correct letter choice.\n\n"
+"tag": "mmlu_flan_no_cot_zeroshot_stem"
+"include": "_mmlu_flan_no_cot_zeroshot_template_yaml"
+"task": "mmlu_flan_no_cot_zeroshot_abstract_algebra"

--- a/lm_eval/tasks/mmlu/flan_no_cot_zeroshot/mmlu_anatomy.yaml
+++ b/lm_eval/tasks/mmlu/flan_no_cot_zeroshot/mmlu_anatomy.yaml
@@ -1,0 +1,5 @@
+"dataset_name": "anatomy"
+"description": "The following are multiple choice questions (with answers) about anatomy. Your response should be concise, and you should end with \"The answer is (X)\", where X is the correct letter choice.\n\n"
+"tag": "mmlu_flan_no_cot_zeroshot_stem"
+"include": "_mmlu_flan_no_cot_zeroshot_template_yaml"
+"task": "mmlu_flan_no_cot_zeroshot_anatomy"

--- a/lm_eval/tasks/mmlu/flan_no_cot_zeroshot/mmlu_astronomy.yaml
+++ b/lm_eval/tasks/mmlu/flan_no_cot_zeroshot/mmlu_astronomy.yaml
@@ -1,0 +1,5 @@
+"dataset_name": "astronomy"
+"description": "The following are multiple choice questions (with answers) about astronomy. Your response should be concise, and you should end with \"The answer is (X)\", where X is the correct letter choice.\n\n"
+"tag": "mmlu_flan_no_cot_zeroshot_stem"
+"include": "_mmlu_flan_no_cot_zeroshot_template_yaml"
+"task": "mmlu_flan_no_cot_zeroshot_astronomy"

--- a/lm_eval/tasks/mmlu/flan_no_cot_zeroshot/mmlu_business_ethics.yaml
+++ b/lm_eval/tasks/mmlu/flan_no_cot_zeroshot/mmlu_business_ethics.yaml
@@ -1,0 +1,6 @@
+"dataset_name": "business_ethics"
+"description": "The following are multiple choice questions (with answers) about business\
+  \ ethics. Your response should be concise, and you should end with \"The answer is (X)\", where X is the correct letter choice.\n\n"
+"tag": "mmlu_flan_no_cot_zeroshot_other"
+"include": "_mmlu_flan_no_cot_zeroshot_template_yaml"
+"task": "mmlu_flan_no_cot_zeroshot_business_ethics"

--- a/lm_eval/tasks/mmlu/flan_no_cot_zeroshot/mmlu_clinical_knowledge.yaml
+++ b/lm_eval/tasks/mmlu/flan_no_cot_zeroshot/mmlu_clinical_knowledge.yaml
@@ -1,0 +1,6 @@
+"dataset_name": "clinical_knowledge"
+"description": "The following are multiple choice questions (with answers) about clinical\
+  \ knowledge. Your response should be concise, and you should end with \"The answer is (X)\", where X is the correct letter choice.\n\n"
+"tag": "mmlu_flan_no_cot_zeroshot_other"
+"include": "_mmlu_flan_no_cot_zeroshot_template_yaml"
+"task": "mmlu_flan_no_cot_zeroshot_clinical_knowledge"

--- a/lm_eval/tasks/mmlu/flan_no_cot_zeroshot/mmlu_college_biology.yaml
+++ b/lm_eval/tasks/mmlu/flan_no_cot_zeroshot/mmlu_college_biology.yaml
@@ -1,0 +1,6 @@
+"dataset_name": "college_biology"
+"description": "The following are multiple choice questions (with answers) about college\
+  \ biology. Your response should be concise, and you should end with \"The answer is (X)\", where X is the correct letter choice.\n\n"
+"tag": "mmlu_flan_no_cot_zeroshot_stem"
+"include": "_mmlu_flan_no_cot_zeroshot_template_yaml"
+"task": "mmlu_flan_no_cot_zeroshot_college_biology"

--- a/lm_eval/tasks/mmlu/flan_no_cot_zeroshot/mmlu_college_chemistry.yaml
+++ b/lm_eval/tasks/mmlu/flan_no_cot_zeroshot/mmlu_college_chemistry.yaml
@@ -1,0 +1,6 @@
+"dataset_name": "college_chemistry"
+"description": "The following are multiple choice questions (with answers) about college\
+  \ chemistry. Your response should be concise, and you should end with \"The answer is (X)\", where X is the correct letter choice.\n\n"
+"tag": "mmlu_flan_no_cot_zeroshot_stem"
+"include": "_mmlu_flan_no_cot_zeroshot_template_yaml"
+"task": "mmlu_flan_no_cot_zeroshot_college_chemistry"

--- a/lm_eval/tasks/mmlu/flan_no_cot_zeroshot/mmlu_college_computer_science.yaml
+++ b/lm_eval/tasks/mmlu/flan_no_cot_zeroshot/mmlu_college_computer_science.yaml
@@ -1,0 +1,6 @@
+"dataset_name": "college_computer_science"
+"description": "The following are multiple choice questions (with answers) about college\
+  \ computer science. Your response should be concise, and you should end with \"The answer is (X)\", where X is the correct letter choice.\n\n"
+"tag": "mmlu_flan_no_cot_zeroshot_stem"
+"include": "_mmlu_flan_no_cot_zeroshot_template_yaml"
+"task": "mmlu_flan_no_cot_zeroshot_college_computer_science"

--- a/lm_eval/tasks/mmlu/flan_no_cot_zeroshot/mmlu_college_mathematics.yaml
+++ b/lm_eval/tasks/mmlu/flan_no_cot_zeroshot/mmlu_college_mathematics.yaml
@@ -1,0 +1,6 @@
+"dataset_name": "college_mathematics"
+"description": "The following are multiple choice questions (with answers) about college\
+  \ mathematics. Your response should be concise, and you should end with \"The answer is (X)\", where X is the correct letter choice.\n\n"
+"tag": "mmlu_flan_no_cot_zeroshot_stem"
+"include": "_mmlu_flan_no_cot_zeroshot_template_yaml"
+"task": "mmlu_flan_no_cot_zeroshot_college_mathematics"

--- a/lm_eval/tasks/mmlu/flan_no_cot_zeroshot/mmlu_college_medicine.yaml
+++ b/lm_eval/tasks/mmlu/flan_no_cot_zeroshot/mmlu_college_medicine.yaml
@@ -1,0 +1,6 @@
+"dataset_name": "college_medicine"
+"description": "The following are multiple choice questions (with answers) about college\
+  \ medicine. Your response should be concise, and you should end with \"The answer is (X)\", where X is the correct letter choice.\n\n"
+"tag": "mmlu_flan_no_cot_zeroshot_other"
+"include": "_mmlu_flan_no_cot_zeroshot_template_yaml"
+"task": "mmlu_flan_no_cot_zeroshot_college_medicine"

--- a/lm_eval/tasks/mmlu/flan_no_cot_zeroshot/mmlu_college_physics.yaml
+++ b/lm_eval/tasks/mmlu/flan_no_cot_zeroshot/mmlu_college_physics.yaml
@@ -1,0 +1,6 @@
+"dataset_name": "college_physics"
+"description": "The following are multiple choice questions (with answers) about college\
+  \ physics. Your response should be concise, and you should end with \"The answer is (X)\", where X is the correct letter choice.\n\n"
+"tag": "mmlu_flan_no_cot_zeroshot_stem"
+"include": "_mmlu_flan_no_cot_zeroshot_template_yaml"
+"task": "mmlu_flan_no_cot_zeroshot_college_physics"

--- a/lm_eval/tasks/mmlu/flan_no_cot_zeroshot/mmlu_computer_security.yaml
+++ b/lm_eval/tasks/mmlu/flan_no_cot_zeroshot/mmlu_computer_security.yaml
@@ -1,0 +1,6 @@
+"dataset_name": "computer_security"
+"description": "The following are multiple choice questions (with answers) about computer\
+  \ security. Your response should be concise, and you should end with \"The answer is (X)\", where X is the correct letter choice.\n\n"
+"tag": "mmlu_flan_no_cot_zeroshot_stem"
+"include": "_mmlu_flan_no_cot_zeroshot_template_yaml"
+"task": "mmlu_flan_no_cot_zeroshot_computer_security"

--- a/lm_eval/tasks/mmlu/flan_no_cot_zeroshot/mmlu_conceptual_physics.yaml
+++ b/lm_eval/tasks/mmlu/flan_no_cot_zeroshot/mmlu_conceptual_physics.yaml
@@ -1,0 +1,6 @@
+"dataset_name": "conceptual_physics"
+"description": "The following are multiple choice questions (with answers) about conceptual\
+  \ physics. Your response should be concise, and you should end with \"The answer is (X)\", where X is the correct letter choice.\n\n"
+"tag": "mmlu_flan_no_cot_zeroshot_stem"
+"include": "_mmlu_flan_no_cot_zeroshot_template_yaml"
+"task": "mmlu_flan_no_cot_zeroshot_conceptual_physics"

--- a/lm_eval/tasks/mmlu/flan_no_cot_zeroshot/mmlu_econometrics.yaml
+++ b/lm_eval/tasks/mmlu/flan_no_cot_zeroshot/mmlu_econometrics.yaml
@@ -1,0 +1,5 @@
+"dataset_name": "econometrics"
+"description": "The following are multiple choice questions (with answers) about econometrics. Your response should be concise, and you should end with \"The answer is (X)\", where X is the correct letter choice.\n\n"
+"tag": "mmlu_flan_no_cot_zeroshot_social_sciences"
+"include": "_mmlu_flan_no_cot_zeroshot_template_yaml"
+"task": "mmlu_flan_no_cot_zeroshot_econometrics"

--- a/lm_eval/tasks/mmlu/flan_no_cot_zeroshot/mmlu_electrical_engineering.yaml
+++ b/lm_eval/tasks/mmlu/flan_no_cot_zeroshot/mmlu_electrical_engineering.yaml
@@ -1,0 +1,6 @@
+"dataset_name": "electrical_engineering"
+"description": "The following are multiple choice questions (with answers) about electrical\
+  \ engineering. Your response should be concise, and you should end with \"The answer is (X)\", where X is the correct letter choice.\n\n"
+"tag": "mmlu_flan_no_cot_zeroshot_stem"
+"include": "_mmlu_flan_no_cot_zeroshot_template_yaml"
+"task": "mmlu_flan_no_cot_zeroshot_electrical_engineering"

--- a/lm_eval/tasks/mmlu/flan_no_cot_zeroshot/mmlu_elementary_mathematics.yaml
+++ b/lm_eval/tasks/mmlu/flan_no_cot_zeroshot/mmlu_elementary_mathematics.yaml
@@ -1,0 +1,6 @@
+"dataset_name": "elementary_mathematics"
+"description": "The following are multiple choice questions (with answers) about elementary\
+  \ mathematics. Your response should be concise, and you should end with \"The answer is (X)\", where X is the correct letter choice.\n\n"
+"tag": "mmlu_flan_no_cot_zeroshot_stem"
+"include": "_mmlu_flan_no_cot_zeroshot_template_yaml"
+"task": "mmlu_flan_no_cot_zeroshot_elementary_mathematics"

--- a/lm_eval/tasks/mmlu/flan_no_cot_zeroshot/mmlu_formal_logic.yaml
+++ b/lm_eval/tasks/mmlu/flan_no_cot_zeroshot/mmlu_formal_logic.yaml
@@ -1,0 +1,6 @@
+"dataset_name": "formal_logic"
+"description": "The following are multiple choice questions (with answers) about formal\
+  \ logic. Your response should be concise, and you should end with \"The answer is (X)\", where X is the correct letter choice.\n\n"
+"tag": "mmlu_flan_no_cot_zeroshot_humanities"
+"include": "_mmlu_flan_no_cot_zeroshot_template_yaml"
+"task": "mmlu_flan_no_cot_zeroshot_formal_logic"

--- a/lm_eval/tasks/mmlu/flan_no_cot_zeroshot/mmlu_global_facts.yaml
+++ b/lm_eval/tasks/mmlu/flan_no_cot_zeroshot/mmlu_global_facts.yaml
@@ -1,0 +1,6 @@
+"dataset_name": "global_facts"
+"description": "The following are multiple choice questions (with answers) about global\
+  \ facts. Your response should be concise, and you should end with \"The answer is (X)\", where X is the correct letter choice.\n\n"
+"tag": "mmlu_flan_no_cot_zeroshot_other"
+"include": "_mmlu_flan_no_cot_zeroshot_template_yaml"
+"task": "mmlu_flan_no_cot_zeroshot_global_facts"

--- a/lm_eval/tasks/mmlu/flan_no_cot_zeroshot/mmlu_high_school_biology.yaml
+++ b/lm_eval/tasks/mmlu/flan_no_cot_zeroshot/mmlu_high_school_biology.yaml
@@ -1,0 +1,6 @@
+"dataset_name": "high_school_biology"
+"description": "The following are multiple choice questions (with answers) about high\
+  \ school biology. Your response should be concise, and you should end with \"The answer is (X)\", where X is the correct letter choice.\n\n"
+"tag": "mmlu_flan_no_cot_zeroshot_stem"
+"include": "_mmlu_flan_no_cot_zeroshot_template_yaml"
+"task": "mmlu_flan_no_cot_zeroshot_high_school_biology"

--- a/lm_eval/tasks/mmlu/flan_no_cot_zeroshot/mmlu_high_school_chemistry.yaml
+++ b/lm_eval/tasks/mmlu/flan_no_cot_zeroshot/mmlu_high_school_chemistry.yaml
@@ -1,0 +1,6 @@
+"dataset_name": "high_school_chemistry"
+"description": "The following are multiple choice questions (with answers) about high\
+  \ school chemistry. Your response should be concise, and you should end with \"The answer is (X)\", where X is the correct letter choice.\n\n"
+"tag": "mmlu_flan_no_cot_zeroshot_stem"
+"include": "_mmlu_flan_no_cot_zeroshot_template_yaml"
+"task": "mmlu_flan_no_cot_zeroshot_high_school_chemistry"

--- a/lm_eval/tasks/mmlu/flan_no_cot_zeroshot/mmlu_high_school_computer_science.yaml
+++ b/lm_eval/tasks/mmlu/flan_no_cot_zeroshot/mmlu_high_school_computer_science.yaml
@@ -1,0 +1,6 @@
+"dataset_name": "high_school_computer_science"
+"description": "The following are multiple choice questions (with answers) about high\
+  \ school computer science. Your response should be concise, and you should end with \"The answer is (X)\", where X is the correct letter choice.\n\n"
+"tag": "mmlu_flan_no_cot_zeroshot_stem"
+"include": "_mmlu_flan_no_cot_zeroshot_template_yaml"
+"task": "mmlu_flan_no_cot_zeroshot_high_school_computer_science"

--- a/lm_eval/tasks/mmlu/flan_no_cot_zeroshot/mmlu_high_school_european_history.yaml
+++ b/lm_eval/tasks/mmlu/flan_no_cot_zeroshot/mmlu_high_school_european_history.yaml
@@ -1,0 +1,6 @@
+"dataset_name": "high_school_european_history"
+"description": "The following are multiple choice questions (with answers) about high\
+  \ school european history. Your response should be concise, and you should end with \"The answer is (X)\", where X is the correct letter choice.\n\n"
+"tag": "mmlu_flan_no_cot_zeroshot_humanities"
+"include": "_mmlu_flan_no_cot_zeroshot_template_yaml"
+"task": "mmlu_flan_no_cot_zeroshot_high_school_european_history"

--- a/lm_eval/tasks/mmlu/flan_no_cot_zeroshot/mmlu_high_school_geography.yaml
+++ b/lm_eval/tasks/mmlu/flan_no_cot_zeroshot/mmlu_high_school_geography.yaml
@@ -1,0 +1,6 @@
+"dataset_name": "high_school_geography"
+"description": "The following are multiple choice questions (with answers) about high\
+  \ school geography. Your response should be concise, and you should end with \"The answer is (X)\", where X is the correct letter choice.\n\n"
+"tag": "mmlu_flan_no_cot_zeroshot_social_sciences"
+"include": "_mmlu_flan_no_cot_zeroshot_template_yaml"
+"task": "mmlu_flan_no_cot_zeroshot_high_school_geography"

--- a/lm_eval/tasks/mmlu/flan_no_cot_zeroshot/mmlu_high_school_government_and_politics.yaml
+++ b/lm_eval/tasks/mmlu/flan_no_cot_zeroshot/mmlu_high_school_government_and_politics.yaml
@@ -1,0 +1,6 @@
+"dataset_name": "high_school_government_and_politics"
+"description": "The following are multiple choice questions (with answers) about high\
+  \ school government and politics. Your response should be concise, and you should end with \"The answer is (X)\", where X is the correct letter choice.\n\n"
+"tag": "mmlu_flan_no_cot_zeroshot_social_sciences"
+"include": "_mmlu_flan_no_cot_zeroshot_template_yaml"
+"task": "mmlu_flan_no_cot_zeroshot_high_school_government_and_politics"

--- a/lm_eval/tasks/mmlu/flan_no_cot_zeroshot/mmlu_high_school_macroeconomics.yaml
+++ b/lm_eval/tasks/mmlu/flan_no_cot_zeroshot/mmlu_high_school_macroeconomics.yaml
@@ -1,0 +1,6 @@
+"dataset_name": "high_school_macroeconomics"
+"description": "The following are multiple choice questions (with answers) about high\
+  \ school macroeconomics. Your response should be concise, and you should end with \"The answer is (X)\", where X is the correct letter choice.\n\n"
+"tag": "mmlu_flan_no_cot_zeroshot_social_sciences"
+"include": "_mmlu_flan_no_cot_zeroshot_template_yaml"
+"task": "mmlu_flan_no_cot_zeroshot_high_school_macroeconomics"

--- a/lm_eval/tasks/mmlu/flan_no_cot_zeroshot/mmlu_high_school_mathematics.yaml
+++ b/lm_eval/tasks/mmlu/flan_no_cot_zeroshot/mmlu_high_school_mathematics.yaml
@@ -1,0 +1,6 @@
+"dataset_name": "high_school_mathematics"
+"description": "The following are multiple choice questions (with answers) about high\
+  \ school mathematics. Your response should be concise, and you should end with \"The answer is (X)\", where X is the correct letter choice.\n\n"
+"tag": "mmlu_flan_no_cot_zeroshot_stem"
+"include": "_mmlu_flan_no_cot_zeroshot_template_yaml"
+"task": "mmlu_flan_no_cot_zeroshot_high_school_mathematics"

--- a/lm_eval/tasks/mmlu/flan_no_cot_zeroshot/mmlu_high_school_microeconomics.yaml
+++ b/lm_eval/tasks/mmlu/flan_no_cot_zeroshot/mmlu_high_school_microeconomics.yaml
@@ -1,0 +1,6 @@
+"dataset_name": "high_school_microeconomics"
+"description": "The following are multiple choice questions (with answers) about high\
+  \ school microeconomics. Your response should be concise, and you should end with \"The answer is (X)\", where X is the correct letter choice.\n\n"
+"tag": "mmlu_flan_no_cot_zeroshot_social_sciences"
+"include": "_mmlu_flan_no_cot_zeroshot_template_yaml"
+"task": "mmlu_flan_no_cot_zeroshot_high_school_microeconomics"

--- a/lm_eval/tasks/mmlu/flan_no_cot_zeroshot/mmlu_high_school_physics.yaml
+++ b/lm_eval/tasks/mmlu/flan_no_cot_zeroshot/mmlu_high_school_physics.yaml
@@ -1,0 +1,6 @@
+"dataset_name": "high_school_physics"
+"description": "The following are multiple choice questions (with answers) about high\
+  \ school physics. Your response should be concise, and you should end with \"The answer is (X)\", where X is the correct letter choice.\n\n"
+"tag": "mmlu_flan_no_cot_zeroshot_stem"
+"include": "_mmlu_flan_no_cot_zeroshot_template_yaml"
+"task": "mmlu_flan_no_cot_zeroshot_high_school_physics"

--- a/lm_eval/tasks/mmlu/flan_no_cot_zeroshot/mmlu_high_school_psychology.yaml
+++ b/lm_eval/tasks/mmlu/flan_no_cot_zeroshot/mmlu_high_school_psychology.yaml
@@ -1,0 +1,6 @@
+"dataset_name": "high_school_psychology"
+"description": "The following are multiple choice questions (with answers) about high\
+  \ school psychology. Your response should be concise, and you should end with \"The answer is (X)\", where X is the correct letter choice.\n\n"
+"tag": "mmlu_flan_no_cot_zeroshot_social_sciences"
+"include": "_mmlu_flan_no_cot_zeroshot_template_yaml"
+"task": "mmlu_flan_no_cot_zeroshot_high_school_psychology"

--- a/lm_eval/tasks/mmlu/flan_no_cot_zeroshot/mmlu_high_school_statistics.yaml
+++ b/lm_eval/tasks/mmlu/flan_no_cot_zeroshot/mmlu_high_school_statistics.yaml
@@ -1,0 +1,6 @@
+"dataset_name": "high_school_statistics"
+"description": "The following are multiple choice questions (with answers) about high\
+  \ school statistics. Your response should be concise, and you should end with \"The answer is (X)\", where X is the correct letter choice.\n\n"
+"tag": "mmlu_flan_no_cot_zeroshot_stem"
+"include": "_mmlu_flan_no_cot_zeroshot_template_yaml"
+"task": "mmlu_flan_no_cot_zeroshot_high_school_statistics"

--- a/lm_eval/tasks/mmlu/flan_no_cot_zeroshot/mmlu_high_school_us_history.yaml
+++ b/lm_eval/tasks/mmlu/flan_no_cot_zeroshot/mmlu_high_school_us_history.yaml
@@ -1,0 +1,6 @@
+"dataset_name": "high_school_us_history"
+"description": "The following are multiple choice questions (with answers) about high\
+  \ school us history. Your response should be concise, and you should end with \"The answer is (X)\", where X is the correct letter choice.\n\n"
+"tag": "mmlu_flan_no_cot_zeroshot_humanities"
+"include": "_mmlu_flan_no_cot_zeroshot_template_yaml"
+"task": "mmlu_flan_no_cot_zeroshot_high_school_us_history"

--- a/lm_eval/tasks/mmlu/flan_no_cot_zeroshot/mmlu_high_school_world_history.yaml
+++ b/lm_eval/tasks/mmlu/flan_no_cot_zeroshot/mmlu_high_school_world_history.yaml
@@ -1,0 +1,6 @@
+"dataset_name": "high_school_world_history"
+"description": "The following are multiple choice questions (with answers) about high\
+  \ school world history. Your response should be concise, and you should end with \"The answer is (X)\", where X is the correct letter choice.\n\n"
+"tag": "mmlu_flan_no_cot_zeroshot_humanities"
+"include": "_mmlu_flan_no_cot_zeroshot_template_yaml"
+"task": "mmlu_flan_no_cot_zeroshot_high_school_world_history"

--- a/lm_eval/tasks/mmlu/flan_no_cot_zeroshot/mmlu_human_aging.yaml
+++ b/lm_eval/tasks/mmlu/flan_no_cot_zeroshot/mmlu_human_aging.yaml
@@ -1,0 +1,6 @@
+"dataset_name": "human_aging"
+"description": "The following are multiple choice questions (with answers) about human\
+  \ aging. Your response should be concise, and you should end with \"The answer is (X)\", where X is the correct letter choice.\n\n"
+"tag": "mmlu_flan_no_cot_zeroshot_other"
+"include": "_mmlu_flan_no_cot_zeroshot_template_yaml"
+"task": "mmlu_flan_no_cot_zeroshot_human_aging"

--- a/lm_eval/tasks/mmlu/flan_no_cot_zeroshot/mmlu_human_sexuality.yaml
+++ b/lm_eval/tasks/mmlu/flan_no_cot_zeroshot/mmlu_human_sexuality.yaml
@@ -1,0 +1,6 @@
+"dataset_name": "human_sexuality"
+"description": "The following are multiple choice questions (with answers) about human\
+  \ sexuality. Your response should be concise, and you should end with \"The answer is (X)\", where X is the correct letter choice.\n\n"
+"tag": "mmlu_flan_no_cot_zeroshot_social_sciences"
+"include": "_mmlu_flan_no_cot_zeroshot_template_yaml"
+"task": "mmlu_flan_no_cot_zeroshot_human_sexuality"

--- a/lm_eval/tasks/mmlu/flan_no_cot_zeroshot/mmlu_international_law.yaml
+++ b/lm_eval/tasks/mmlu/flan_no_cot_zeroshot/mmlu_international_law.yaml
@@ -1,0 +1,6 @@
+"dataset_name": "international_law"
+"description": "The following are multiple choice questions (with answers) about international\
+  \ law. Your response should be concise, and you should end with \"The answer is (X)\", where X is the correct letter choice.\n\n"
+"tag": "mmlu_flan_no_cot_zeroshot_humanities"
+"include": "_mmlu_flan_no_cot_zeroshot_template_yaml"
+"task": "mmlu_flan_no_cot_zeroshot_international_law"

--- a/lm_eval/tasks/mmlu/flan_no_cot_zeroshot/mmlu_jurisprudence.yaml
+++ b/lm_eval/tasks/mmlu/flan_no_cot_zeroshot/mmlu_jurisprudence.yaml
@@ -1,0 +1,5 @@
+"dataset_name": "jurisprudence"
+"description": "The following are multiple choice questions (with answers) about jurisprudence. Your response should be concise, and you should end with \"The answer is (X)\", where X is the correct letter choice.\n\n"
+"tag": "mmlu_flan_no_cot_zeroshot_humanities"
+"include": "_mmlu_flan_no_cot_zeroshot_template_yaml"
+"task": "mmlu_flan_no_cot_zeroshot_jurisprudence"

--- a/lm_eval/tasks/mmlu/flan_no_cot_zeroshot/mmlu_logical_fallacies.yaml
+++ b/lm_eval/tasks/mmlu/flan_no_cot_zeroshot/mmlu_logical_fallacies.yaml
@@ -1,0 +1,6 @@
+"dataset_name": "logical_fallacies"
+"description": "The following are multiple choice questions (with answers) about logical\
+  \ fallacies. Your response should be concise, and you should end with \"The answer is (X)\", where X is the correct letter choice.\n\n"
+"tag": "mmlu_flan_no_cot_zeroshot_humanities"
+"include": "_mmlu_flan_no_cot_zeroshot_template_yaml"
+"task": "mmlu_flan_no_cot_zeroshot_logical_fallacies"

--- a/lm_eval/tasks/mmlu/flan_no_cot_zeroshot/mmlu_machine_learning.yaml
+++ b/lm_eval/tasks/mmlu/flan_no_cot_zeroshot/mmlu_machine_learning.yaml
@@ -1,0 +1,6 @@
+"dataset_name": "machine_learning"
+"description": "The following are multiple choice questions (with answers) about machine\
+  \ learning. Your response should be concise, and you should end with \"The answer is (X)\", where X is the correct letter choice.\n\n"
+"tag": "mmlu_flan_no_cot_zeroshot_stem"
+"include": "_mmlu_flan_no_cot_zeroshot_template_yaml"
+"task": "mmlu_flan_no_cot_zeroshot_machine_learning"

--- a/lm_eval/tasks/mmlu/flan_no_cot_zeroshot/mmlu_management.yaml
+++ b/lm_eval/tasks/mmlu/flan_no_cot_zeroshot/mmlu_management.yaml
@@ -1,0 +1,5 @@
+"dataset_name": "management"
+"description": "The following are multiple choice questions (with answers) about management. Your response should be concise, and you should end with \"The answer is (X)\", where X is the correct letter choice.\n\n"
+"tag": "mmlu_flan_no_cot_zeroshot_other"
+"include": "_mmlu_flan_no_cot_zeroshot_template_yaml"
+"task": "mmlu_flan_no_cot_zeroshot_management"

--- a/lm_eval/tasks/mmlu/flan_no_cot_zeroshot/mmlu_marketing.yaml
+++ b/lm_eval/tasks/mmlu/flan_no_cot_zeroshot/mmlu_marketing.yaml
@@ -1,0 +1,5 @@
+"dataset_name": "marketing"
+"description": "The following are multiple choice questions (with answers) about marketing. Your response should be concise, and you should end with \"The answer is (X)\", where X is the correct letter choice.\n\n"
+"tag": "mmlu_flan_no_cot_zeroshot_other"
+"include": "_mmlu_flan_no_cot_zeroshot_template_yaml"
+"task": "mmlu_flan_no_cot_zeroshot_marketing"

--- a/lm_eval/tasks/mmlu/flan_no_cot_zeroshot/mmlu_medical_genetics.yaml
+++ b/lm_eval/tasks/mmlu/flan_no_cot_zeroshot/mmlu_medical_genetics.yaml
@@ -1,0 +1,6 @@
+"dataset_name": "medical_genetics"
+"description": "The following are multiple choice questions (with answers) about medical\
+  \ genetics. Your response should be concise, and you should end with \"The answer is (X)\", where X is the correct letter choice.\n\n"
+"tag": "mmlu_flan_no_cot_zeroshot_other"
+"include": "_mmlu_flan_no_cot_zeroshot_template_yaml"
+"task": "mmlu_flan_no_cot_zeroshot_medical_genetics"

--- a/lm_eval/tasks/mmlu/flan_no_cot_zeroshot/mmlu_miscellaneous.yaml
+++ b/lm_eval/tasks/mmlu/flan_no_cot_zeroshot/mmlu_miscellaneous.yaml
@@ -1,0 +1,5 @@
+"dataset_name": "miscellaneous"
+"description": "The following are multiple choice questions (with answers) about miscellaneous. Your response should be concise, and you should end with \"The answer is (X)\", where X is the correct letter choice.\n\n"
+"tag": "mmlu_flan_no_cot_zeroshot_other"
+"include": "_mmlu_flan_no_cot_zeroshot_template_yaml"
+"task": "mmlu_flan_no_cot_zeroshot_miscellaneous"

--- a/lm_eval/tasks/mmlu/flan_no_cot_zeroshot/mmlu_moral_disputes.yaml
+++ b/lm_eval/tasks/mmlu/flan_no_cot_zeroshot/mmlu_moral_disputes.yaml
@@ -1,0 +1,6 @@
+"dataset_name": "moral_disputes"
+"description": "The following are multiple choice questions (with answers) about moral\
+  \ disputes. Your response should be concise, and you should end with \"The answer is (X)\", where X is the correct letter choice.\n\n"
+"tag": "mmlu_flan_no_cot_zeroshot_humanities"
+"include": "_mmlu_flan_no_cot_zeroshot_template_yaml"
+"task": "mmlu_flan_no_cot_zeroshot_moral_disputes"

--- a/lm_eval/tasks/mmlu/flan_no_cot_zeroshot/mmlu_moral_scenarios.yaml
+++ b/lm_eval/tasks/mmlu/flan_no_cot_zeroshot/mmlu_moral_scenarios.yaml
@@ -1,0 +1,6 @@
+"dataset_name": "moral_scenarios"
+"description": "The following are multiple choice questions (with answers) about moral\
+  \ scenarios. Your response should be concise, and you should end with \"The answer is (X)\", where X is the correct letter choice.\n\n"
+"tag": "mmlu_flan_no_cot_zeroshot_humanities"
+"include": "_mmlu_flan_no_cot_zeroshot_template_yaml"
+"task": "mmlu_flan_no_cot_zeroshot_moral_scenarios"

--- a/lm_eval/tasks/mmlu/flan_no_cot_zeroshot/mmlu_nutrition.yaml
+++ b/lm_eval/tasks/mmlu/flan_no_cot_zeroshot/mmlu_nutrition.yaml
@@ -1,0 +1,5 @@
+"dataset_name": "nutrition"
+"description": "The following are multiple choice questions (with answers) about nutrition. Your response should be concise, and you should end with \"The answer is (X)\", where X is the correct letter choice.\n\n"
+"tag": "mmlu_flan_no_cot_zeroshot_other"
+"include": "_mmlu_flan_no_cot_zeroshot_template_yaml"
+"task": "mmlu_flan_no_cot_zeroshot_nutrition"

--- a/lm_eval/tasks/mmlu/flan_no_cot_zeroshot/mmlu_philosophy.yaml
+++ b/lm_eval/tasks/mmlu/flan_no_cot_zeroshot/mmlu_philosophy.yaml
@@ -1,0 +1,5 @@
+"dataset_name": "philosophy"
+"description": "The following are multiple choice questions (with answers) about philosophy. Your response should be concise, and you should end with \"The answer is (X)\", where X is the correct letter choice.\n\n"
+"tag": "mmlu_flan_no_cot_zeroshot_humanities"
+"include": "_mmlu_flan_no_cot_zeroshot_template_yaml"
+"task": "mmlu_flan_no_cot_zeroshot_philosophy"

--- a/lm_eval/tasks/mmlu/flan_no_cot_zeroshot/mmlu_prehistory.yaml
+++ b/lm_eval/tasks/mmlu/flan_no_cot_zeroshot/mmlu_prehistory.yaml
@@ -1,0 +1,5 @@
+"dataset_name": "prehistory"
+"description": "The following are multiple choice questions (with answers) about prehistory. Your response should be concise, and you should end with \"The answer is (X)\", where X is the correct letter choice.\n\n"
+"tag": "mmlu_flan_no_cot_zeroshot_humanities"
+"include": "_mmlu_flan_no_cot_zeroshot_template_yaml"
+"task": "mmlu_flan_no_cot_zeroshot_prehistory"

--- a/lm_eval/tasks/mmlu/flan_no_cot_zeroshot/mmlu_professional_accounting.yaml
+++ b/lm_eval/tasks/mmlu/flan_no_cot_zeroshot/mmlu_professional_accounting.yaml
@@ -1,0 +1,6 @@
+"dataset_name": "professional_accounting"
+"description": "The following are multiple choice questions (with answers) about professional\
+  \ accounting. Your response should be concise, and you should end with \"The answer is (X)\", where X is the correct letter choice.\n\n"
+"tag": "mmlu_flan_no_cot_zeroshot_other"
+"include": "_mmlu_flan_no_cot_zeroshot_template_yaml"
+"task": "mmlu_flan_no_cot_zeroshot_professional_accounting"

--- a/lm_eval/tasks/mmlu/flan_no_cot_zeroshot/mmlu_professional_law.yaml
+++ b/lm_eval/tasks/mmlu/flan_no_cot_zeroshot/mmlu_professional_law.yaml
@@ -1,0 +1,6 @@
+"dataset_name": "professional_law"
+"description": "The following are multiple choice questions (with answers) about professional\
+  \ law. Your response should be concise, and you should end with \"The answer is (X)\", where X is the correct letter choice.\n\n"
+"tag": "mmlu_flan_no_cot_zeroshot_humanities"
+"include": "_mmlu_flan_no_cot_zeroshot_template_yaml"
+"task": "mmlu_flan_no_cot_zeroshot_professional_law"

--- a/lm_eval/tasks/mmlu/flan_no_cot_zeroshot/mmlu_professional_medicine.yaml
+++ b/lm_eval/tasks/mmlu/flan_no_cot_zeroshot/mmlu_professional_medicine.yaml
@@ -1,0 +1,6 @@
+"dataset_name": "professional_medicine"
+"description": "The following are multiple choice questions (with answers) about professional\
+  \ medicine. Your response should be concise, and you should end with \"The answer is (X)\", where X is the correct letter choice.\n\n"
+"tag": "mmlu_flan_no_cot_zeroshot_other"
+"include": "_mmlu_flan_no_cot_zeroshot_template_yaml"
+"task": "mmlu_flan_no_cot_zeroshot_professional_medicine"

--- a/lm_eval/tasks/mmlu/flan_no_cot_zeroshot/mmlu_professional_psychology.yaml
+++ b/lm_eval/tasks/mmlu/flan_no_cot_zeroshot/mmlu_professional_psychology.yaml
@@ -1,0 +1,6 @@
+"dataset_name": "professional_psychology"
+"description": "The following are multiple choice questions (with answers) about professional\
+  \ psychology. Your response should be concise, and you should end with \"The answer is (X)\", where X is the correct letter choice.\n\n"
+"tag": "mmlu_flan_no_cot_zeroshot_social_sciences"
+"include": "_mmlu_flan_no_cot_zeroshot_template_yaml"
+"task": "mmlu_flan_no_cot_zeroshot_professional_psychology"

--- a/lm_eval/tasks/mmlu/flan_no_cot_zeroshot/mmlu_public_relations.yaml
+++ b/lm_eval/tasks/mmlu/flan_no_cot_zeroshot/mmlu_public_relations.yaml
@@ -1,0 +1,6 @@
+"dataset_name": "public_relations"
+"description": "The following are multiple choice questions (with answers) about public\
+  \ relations. Your response should be concise, and you should end with \"The answer is (X)\", where X is the correct letter choice.\n\n"
+"tag": "mmlu_flan_no_cot_zeroshot_social_sciences"
+"include": "_mmlu_flan_no_cot_zeroshot_template_yaml"
+"task": "mmlu_flan_no_cot_zeroshot_public_relations"

--- a/lm_eval/tasks/mmlu/flan_no_cot_zeroshot/mmlu_security_studies.yaml
+++ b/lm_eval/tasks/mmlu/flan_no_cot_zeroshot/mmlu_security_studies.yaml
@@ -1,0 +1,6 @@
+"dataset_name": "security_studies"
+"description": "The following are multiple choice questions (with answers) about security\
+  \ studies. Your response should be concise, and you should end with \"The answer is (X)\", where X is the correct letter choice.\n\n"
+"tag": "mmlu_flan_no_cot_zeroshot_social_sciences"
+"include": "_mmlu_flan_no_cot_zeroshot_template_yaml"
+"task": "mmlu_flan_no_cot_zeroshot_security_studies"

--- a/lm_eval/tasks/mmlu/flan_no_cot_zeroshot/mmlu_sociology.yaml
+++ b/lm_eval/tasks/mmlu/flan_no_cot_zeroshot/mmlu_sociology.yaml
@@ -1,0 +1,5 @@
+"dataset_name": "sociology"
+"description": "The following are multiple choice questions (with answers) about sociology. Your response should be concise, and you should end with \"The answer is (X)\", where X is the correct letter choice.\n\n"
+"tag": "mmlu_flan_no_cot_zeroshot_social_sciences"
+"include": "_mmlu_flan_no_cot_zeroshot_template_yaml"
+"task": "mmlu_flan_no_cot_zeroshot_sociology"

--- a/lm_eval/tasks/mmlu/flan_no_cot_zeroshot/mmlu_us_foreign_policy.yaml
+++ b/lm_eval/tasks/mmlu/flan_no_cot_zeroshot/mmlu_us_foreign_policy.yaml
@@ -1,0 +1,6 @@
+"dataset_name": "us_foreign_policy"
+"description": "The following are multiple choice questions (with answers) about us\
+  \ foreign policy. Your response should be concise, and you should end with \"The answer is (X)\", where X is the correct letter choice.\n\n"
+"tag": "mmlu_flan_no_cot_zeroshot_social_sciences"
+"include": "_mmlu_flan_no_cot_zeroshot_template_yaml"
+"task": "mmlu_flan_no_cot_zeroshot_us_foreign_policy"

--- a/lm_eval/tasks/mmlu/flan_no_cot_zeroshot/mmlu_virology.yaml
+++ b/lm_eval/tasks/mmlu/flan_no_cot_zeroshot/mmlu_virology.yaml
@@ -1,0 +1,5 @@
+"dataset_name": "virology"
+"description": "The following are multiple choice questions (with answers) about virology. Your response should be concise, and you should end with \"The answer is (X)\", where X is the correct letter choice.\n\n"
+"tag": "mmlu_flan_no_cot_zeroshot_other"
+"include": "_mmlu_flan_no_cot_zeroshot_template_yaml"
+"task": "mmlu_flan_no_cot_zeroshot_virology"

--- a/lm_eval/tasks/mmlu/flan_no_cot_zeroshot/mmlu_world_religions.yaml
+++ b/lm_eval/tasks/mmlu/flan_no_cot_zeroshot/mmlu_world_religions.yaml
@@ -1,0 +1,6 @@
+"dataset_name": "world_religions"
+"description": "The following are multiple choice questions (with answers) about world\
+  \ religions. Your response should be concise, and you should end with \"The answer is (X)\", where X is the correct letter choice.\n\n"
+"tag": "mmlu_flan_no_cot_zeroshot_humanities"
+"include": "_mmlu_flan_no_cot_zeroshot_template_yaml"
+"task": "mmlu_flan_no_cot_zeroshot_world_religions"

--- a/lm_eval/tasks/mmlu/flan_no_cot_zeroshot/utils.py
+++ b/lm_eval/tasks/mmlu/flan_no_cot_zeroshot/utils.py
@@ -1,0 +1,112 @@
+import re
+import sys
+import unicodedata
+
+from lm_eval.filters.extraction import RegexFilter
+
+
+class MultiChoiceRegexFilter(RegexFilter):
+    """ """
+
+    def __init__(
+        self,
+        regex_pattern: str = r"#### (\-?[0-9\.\,]+)",
+        group_select=0,
+        fallback: str = "[invalid]",
+        ignore_case=False,
+        ignore_punctuation=False,
+        regexes_to_ignore=None,
+    ) -> None:
+        """
+        regex_pattern: The basic regex pattern to use. If fails to match, we will use the customized match procedure
+                        - step 1 : We parse the choices between ([A-Z])s then try to find these choices in the response.
+                        - step 2 : We parse the choice with regex :[\s]*([A-?]), where ? varies by number of choices.
+        group_select: Selects the (group_select)th match from the findall result.
+        ignore_case: Ignores the case during step 1 matching
+        ignore_punctuation: Remove the punctuation during step 1 matching
+        regexes_to_ignore: Remove these regexes during step 1 matching
+        """
+        super().__init__(regex_pattern, group_select, fallback)
+        self.ignore_case = ignore_case
+        self.ignore_punctuation = ignore_punctuation
+        self.regexes_to_ignore = regexes_to_ignore
+
+    def apply(self, resps, docs):
+        # here, we assume we have a list, in which each element is
+        # a list of model responses for some particular input/target pair.
+        # so we process each of these (same input/target response sets)
+        # independently (and keep them a list.)
+
+        def find_match(regex, resp, convert_dict={}):
+            match = regex.findall(resp)
+            if match:
+                match = match[self.group_select]
+                if isinstance(match, tuple):
+                    match = [m for m in match if m][0]
+                match = match.strip()
+                if match and match in convert_dict:
+                    match = convert_dict[match]
+            return match
+
+        punct_tbl = dict.fromkeys(
+            i
+            for i in range(sys.maxunicode)
+            if unicodedata.category(chr(i)).startswith("P")
+        )
+
+        def filter_ignores(st):
+            if self.regexes_to_ignore is not None:
+                for s in self.regexes_to_ignore:
+                    st = re.sub(s, "", st)
+
+            if self.ignore_case:
+                st = st.lower()
+
+            if self.ignore_punctuation:
+                # https://stackoverflow.com/a/266162
+                st = st.translate(punct_tbl)
+            return st
+
+        filtered_resps = []
+
+        for r, doc in zip(resps, docs):
+            fallback_regexes = []
+            choice_to_alpha = {}
+            next_alpha = "A"
+
+            without_paren_fallback_regexes = []
+            without_paren_to_target = {}
+
+            choices = doc["choices"]
+            for c in choices:
+                m = filter_ignores(c.strip())
+                fallback_regexes.append(f"{re.escape(m)}")
+                choice_to_alpha[m] = f"({next_alpha})"
+
+                without_paren_fallback_regexes.append(next_alpha)
+                without_paren_to_target[next_alpha] = f"({next_alpha})"
+
+                next_alpha = chr(ord(next_alpha) + 1)
+            fallback_regex = re.compile("|".join(fallback_regexes))
+            without_paren_fallback_regex = "|".join(without_paren_fallback_regexes)
+            without_paren_fallback_regex = re.compile(
+                f":[\s]*({without_paren_fallback_regex})"
+            )
+
+            filtered = []
+            for resp in r:
+                match = find_match(self.regex, resp)
+                if not match:
+                    match = find_match(
+                        fallback_regex, filter_ignores(resp), choice_to_alpha
+                    )
+                    if not match:
+                        match = find_match(
+                            without_paren_fallback_regex, resp, without_paren_to_target
+                        )
+                if not match:
+                    match = self.fallback
+                filtered.append(match)
+            filtered_resps.append(filtered)
+
+        return filtered_resps


### PR DESCRIPTION
add two other versions of generative zeroshot mmlu: one without system prompt `mmlu_flan_cot_zeroshot_nosystem` (the format instruction is included in the user prompt), and one without the 'Let's think step by step' instruction `mmlu_flan_no_cot_zeroshot` 