### PR TITLE
Fix MLogiQA

### DIFF
--- a/lm_eval/tasks/mlogiqa/README.md
+++ b/lm_eval/tasks/mlogiqa/README.md
@@ -22,6 +22,16 @@ Homepage: https://huggingface.co/datasets/Qwen/P-MMEval/viewer/mlogiqa
 }
 ```
 
+### Implementation
+
+Figure 12 from the original paper shows the prompt used:
+
+> "Passage: {context}\nQuestion: {question}\nChoices:\nA. {option_a}\nB. {option_b}\nC. {option_c}\nD.{option_d}\nPlease choose the most suitable one among A, B, C and Das the answer to this question, and return it in the following JSON format:\n{'answer': '[choice]'}\nwhere [choice] must be one of A, B, C and D."
+
+In this MCQA implementation, we remove the last part of the original prompt:
+
+> "Passage: {context}\nQuestion: {question}\nChoices:\nA. {option_a}\nB. {option_b}\nC. {option_c}\nD.{option_d}\nPlease choose the most suitable one among A, B, C and Das the answer to this question."
+
 ### Groups, Tags, and Tasks
 
 #### Groups

--- a/lm_eval/tasks/mlogiqa/_mlogiqa_yaml
+++ b/lm_eval/tasks/mlogiqa/_mlogiqa_yaml
@@ -1,6 +1,7 @@
 dataset_path: swiss-ai/mlogiqa
 test_split: test
 output_type: multiple_choice
+process_docs: !function utils.process_docs
 doc_to_text: !function utils.doc_to_text
 doc_to_target: "{{answer}}"
 doc_to_choice: !function utils.doc_to_choice

--- a/lm_eval/tasks/mlogiqa/_mlogiqa_yaml
+++ b/lm_eval/tasks/mlogiqa/_mlogiqa_yaml
@@ -1,17 +1,7 @@
 dataset_path: swiss-ai/mlogiqa
 test_split: test
 output_type: multiple_choice
-doc_to_text:  |
-  {{context.strip()}}
-  
-  {{question.strip()}}
-
-  A. {{options[0]}}
-  B. {{options[1]}}
-  C. {{options[2]}}
-  D. {{options[3]}}
-
-  Answer:
+doc_to_text: !function utils.doc_to_text
 doc_to_target: "{{answer}}"
 doc_to_choice: !function utils.doc_to_choice
 metric_list:

--- a/lm_eval/tasks/mlogiqa/utils.py
+++ b/lm_eval/tasks/mlogiqa/utils.py
@@ -1,15 +1,18 @@
 import ast
-
+import datasets
 
 def doc_to_choice(doc):
     """Parse options string to list of choices."""
-    return ast.literal_eval(doc["options"])
+    return [f"{chr(ord('A') + i)}. {x}" for i, x in enumerate(doc["options"])]
+
+def process_docs(dataset: datasets.Dataset) -> datasets.Dataset:
+    return dataset.map(lambda x: {"options": ast.literal_eval(x["options"])})
 
 
 def doc_to_text(doc):
     """Parse options and render the text template."""
-    # Parse the options string into a list
-    options = ast.literal_eval(doc["options"])
+    # # Parse the options string into a list
+    options = doc["options"]
 
     # Build the text template
     text = f"Passage: {doc['context'].strip()}\n"

--- a/lm_eval/tasks/mlogiqa/utils.py
+++ b/lm_eval/tasks/mlogiqa/utils.py
@@ -4,3 +4,21 @@ import ast
 def doc_to_choice(doc):
     """Parse options string to list of choices."""
     return ast.literal_eval(doc["options"])
+
+
+def doc_to_text(doc):
+    """Parse options and render the text template."""
+    # Parse the options string into a list
+    options = ast.literal_eval(doc["options"])
+
+    # Build the text template
+    text = f"Passage: {doc['context'].strip()}\n"
+    text += f"Question: {doc['question'].strip()}\n"
+    text += "Choices:\n"
+    text += f"A. {options[0]}\n"
+    text += f"B. {options[1]}\n"
+    text += f"C. {options[2]}\n"
+    text += f"D. {options[3]}\n"
+    text += "Please choose the most suitable one among A, B, C and D as the answer to this question."
+
+    return text


### PR DESCRIPTION
I have updated the prompt used to match the one from the original paper. Anyway, the current harness implementation of this task is as MCQA. If we want to evaluate as in the paper, we would have to convert it into a generation task that answers in "JSON format:\n{'answer': '[choice]'}\nwhere [choice] must be one of A, B, C and D".