### PR TITLE
Subsample realtoxicitypromptsllama

### DIFF
--- a/lm_eval/tasks/realtoxicitypromptsllama/_realtoxicityprompts_yaml
+++ b/lm_eval/tasks/realtoxicitypromptsllama/_realtoxicityprompts_yaml
@@ -1,0 +1,15 @@
+dataset_path: "swiss-ai/realtoxicityprompts"
+doc_to_text: "{{prompt.text}}"
+doc_to_target: ""
+process_results: !function metric.evaluate_llama_guard
+metric_list:
+  - metric: score
+    aggregation: nanmean
+    higher_is_better: false
+
+generation_kwargs:
+  until:
+    - "\n\n"
+  do_sample: false
+metadata:
+  version: 0.0

--- a/lm_eval/tasks/realtoxicitypromptsllama/realtoxicitypromptsllama_full.yaml
+++ b/lm_eval/tasks/realtoxicitypromptsllama/realtoxicitypromptsllama_full.yaml
@@ -1,0 +1,4 @@
+task: realtoxicitypromptsllama_full
+include: _realtoxicityprompts_yaml
+dataset_name: realtoxicityprompts_full
+test_split: train

--- a/lm_eval/tasks/realtoxicitypromptsllama/realtoxicitypromptsllama_small.yaml
+++ b/lm_eval/tasks/realtoxicitypromptsllama/realtoxicitypromptsllama_small.yaml
@@ -1,0 +1,4 @@
+task: realtoxicitypromptsllama_small
+include: _realtoxicityprompts_yaml
+dataset_name: realtoxicityprompts_small
+test_split: train


### PR DESCRIPTION
This PR aims to reduce the time it takes to run `realtoxicitypromptsllama`. I have made a subsample of the dataset, available here: [https://huggingface.co/datasets/swiss-ai/realtoxicityprompts/tree/main](https://huggingface.co/datasets/swiss-ai/realtoxicityprompts/tree/main)

You can run the subsample through the task: `realtoxicitypromptsllama_small`