### PR TITLE
Reverse scores for harmbench and realtoxicity

### DIFF
--- a/lm_eval/tasks/harmbench/_harmbench_yaml
+++ b/lm_eval/tasks/harmbench/_harmbench_yaml
@@ -8,6 +8,9 @@ metric_list:
   - metric: score
     aggregation: nanmean
     higher_is_better: false
+  - metric: reversed_score
+    aggregation: nanmean
+    higher_is_better: true
 generation_kwargs:
   until: []
   do_sample: false

--- a/lm_eval/tasks/harmbench/harmbench.yaml
+++ b/lm_eval/tasks/harmbench/harmbench.yaml
@@ -6,3 +6,6 @@ aggregate_metric_list:
   - metric: score
     aggregation: mean
     weight_by_size: true
+  - metric: reversed_score
+    aggregation: mean
+    weight_by_size: true

--- a/lm_eval/tasks/harmbench/metrics.py
+++ b/lm_eval/tasks/harmbench/metrics.py
@@ -190,6 +190,7 @@ def compute_results_classifier(behavior_dict, completion, model, tokenizer, temp
         print(f"Warning: Predicted label '{preds}' not in expected labels {labels}. Returning NaN.")
     return {
         "score": p,
+        "reversed_score": 1 - p,
     }
 
 

--- a/lm_eval/tasks/realtoxicityprompts/metric.py
+++ b/lm_eval/tasks/realtoxicityprompts/metric.py
@@ -90,4 +90,8 @@ def toxicity_perspective_api(
             scores.append(0)
             toxicity_scores.append(0)
 
-    return {"score": scores[0], "perspective_api_toxicity_score": toxicity_scores[0]}
+    return {
+        "score": scores[0],
+        "perspective_api_toxicity_score": toxicity_scores[0],
+        "reversed_score": 1 - scores[0],
+    }

--- a/lm_eval/tasks/realtoxicityprompts/realtoxicityprompts.yaml
+++ b/lm_eval/tasks/realtoxicityprompts/realtoxicityprompts.yaml
@@ -1,7 +1,7 @@
 task: realtoxicityprompts
 dataset_path: "allenai/real-toxicity-prompts"
-training_split: 'train'
-test_split: 'train'
+training_split: "train"
+test_split: "train"
 doc_to_text: "{{prompt.text}}"
 doc_to_target: ""
 process_results: !function metric.toxicity_perspective_api
@@ -12,6 +12,9 @@ metric_list:
   - metric: perspective_api_toxicity_score
     aggregation: mean
     higher_is_better: false
+  - metric: reversed_score
+    aggregation: mean
+    higher_is_better: true
 generation_kwargs:
   until:
     - "\n\n"


### PR DESCRIPTION
makes computing averages easier