### PR TITLE
MBPP: Strip leading whitespace, fix indentation in few-shot examples

### DIFF
--- a/lm_eval/tasks/mbpp/utils.py
+++ b/lm_eval/tasks/mbpp/utils.py
@@ -3,6 +3,7 @@ from typing import Union
 
 import evaluate as hf_evaluate
 
+import re
 
 try:
     pass_at_k = hf_evaluate.load("code_eval")
@@ -26,11 +27,20 @@ def pass_at_1(
         references=references,
         predictions=predictions,
         k=[1],
-    )[0]["pass@1"]
+    )[
+        0
+    ]["pass@1"]
 
 
 def clean_text(text: str) -> str:
-    return re.sub(r'\n(▁+)', lambda m: '\n' + ' ' * len(m.group(1)), text)
+    text = re.sub(r"\n(▁+)", lambda m: "\n" + " " * len(m.group(1)), text)
+
+    # strip leading/trailing whitespace
+    text = text.strip()
+    # remove stray leading space before def
+    text = re.sub(r"^\s*def", "def", text, flags=re.MULTILINE)
+    return text
+
 
 def extract_code_blocks(text: str) -> str:
     # Pattern to match ```...``` blocks
@@ -56,7 +66,7 @@ def list_fewshot_samples():
         {
             "task_id": 2,
             "text": "Write a function to find the similar elements from the given two tuple lists.",
-            "code": "def similar_elements(test_tup1, test_tup2):\r\n  res = tuple(set(test_tup1) & set(test_tup2))\r\n  return (res) ",
+            "code": "def similar_elements(test_tup1, test_tup2):\r\n    res = tuple(set(test_tup1) & set(test_tup2))\r\n    return (res) ",
             "test_list": [
                 "assert similar_elements((3, 4, 5, 6),(5, 7, 4, 10)) == (4, 5)",
                 "assert similar_elements((1, 2, 3, 4),(5, 4, 3, 7)) == (3, 4)",
@@ -78,7 +88,7 @@ def list_fewshot_samples():
         {
             "task_id": 4,
             "text": "Write a function to find the largest integers from a given list of numbers using heap queue algorithm.",
-            "code": "import heapq as hq\r\ndef heap_queue_largest(nums,n):\r\n  largest_nums = hq.nlargest(n, nums)\r\n  return largest_nums",
+            "code": "import heapq as hq\r\ndef heap_queue_largest(nums,n):\r\n    largest_nums = hq.nlargest(n, nums)\r\n    return largest_nums",
             "test_list": [
                 "assert heap_queue_largest( [25, 35, 22, 85, 14, 65, 75, 22, 58],3)==[85, 75, 65] ",
                 "assert heap_queue_largest( [25, 35, 22, 85, 14, 65, 75, 22, 58],2)==[85, 75] ",


### PR DESCRIPTION
- Strip leading whitespaces of responses
- Fix indentation in few-shot to 4 spaces