### PR TITLE
Added loading of private datasets from capstore - completes existing benchmark suite 

### DIFF
--- a/env_example
+++ b/env_example
@@ -1,2 +1,3 @@
 HF_TOKEN = ...  # For private datasets in the swiss-ai Hugging Face org
+LM_EVAL_PRIVATE_DATASET_ROOT = /capstor/store/cscs/swissai/infra01/datasets-hf-private  # Optional: local-first override for swiss-ai/switzerland_qa and swiss-ai/include-base-new-45
 PERSPECTIVE_API_KEY = ...  # For RealToxicityPrompts and PolygloToxicityPrompts

--- a/lm_eval/api/task.py
+++ b/lm_eval/api/task.py
@@ -20,7 +20,6 @@ from typing import (
 import datasets
 import numpy as np
 from tqdm import tqdm
-import huggingface_hub
 
 from lm_eval import utils
 from lm_eval.api import samplers
@@ -92,7 +91,9 @@ def _is_saved_dataset_dir(path: Path) -> bool:
     if not path.is_dir():
         return False
     # `datasets.save_to_disk` writes one of these at the root.
-    return (path / "dataset_dict.json").is_file() or (path / "dataset_info.json").is_file()
+    return (path / "dataset_dict.json").is_file() or (
+        path / "dataset_info.json"
+    ).is_file()
 
 
 def _resolve_private_saved_dataset_path(
@@ -620,7 +621,7 @@ class Task(abc.ABC):
         self._config["process_results"] = "process_results"
 
     def set_fewshot_seed(self, seed: int | None = None) -> None:
-        self.fewshot_rnd = random.Random(seed)
+        self.fewshot_rnd = random.Random(seed)  # noqa: S311
         if hasattr(self, "sampler"):
             self.sampler.set_rnd(seed)
 

--- a/lm_eval/api/task.py
+++ b/lm_eval/api/task.py
@@ -3,11 +3,13 @@ from __future__ import annotations
 import abc
 import ast
 import logging
+import os
 import random
 import re
 from collections.abc import Callable, Iterable, Iterator, Mapping
 from copy import deepcopy
 from functools import partial
+from pathlib import Path
 from typing import (
     TYPE_CHECKING,
     Any,
@@ -56,6 +58,34 @@ ALL_OUTPUT_TYPES = [
 ]
 
 eval_logger = logging.getLogger(__name__)
+
+_PRIVATE_DATASET_ROOT_ENV = "LM_EVAL_PRIVATE_DATASET_ROOT"
+_DEFAULT_PRIVATE_DATASET_ROOT = (
+    "/capstor/store/cscs/swissai/infra01/datasets-hf-private"
+)
+_PRIVATE_DATASET_OVERRIDES = {
+    "swiss-ai/switzerland_qa": "swiss-ai__switzerland_qa",
+    "swiss-ai/include-base-new-45": "swiss-ai__include-base-new-45",
+}
+
+
+def _resolve_private_dataset_path(dataset_path: str | None) -> str | None:
+    if dataset_path is None:
+        return None
+
+    relative_path = _PRIVATE_DATASET_OVERRIDES.get(dataset_path)
+    if relative_path is None:
+        return None
+
+    root = os.getenv(_PRIVATE_DATASET_ROOT_ENV, _DEFAULT_PRIVATE_DATASET_ROOT)
+    if not root:
+        return None
+
+    candidate = Path(root) / relative_path
+    if candidate.is_dir():
+        return str(candidate)
+
+    return None
 
 
 TaskConfig = TaskConfig
@@ -863,7 +893,7 @@ class ConfigurableTask(Task):
         if dataset_kwargs and vparse(datasets.__version__) >= vparse("4.0.0"):
             dataset_kwargs.pop("trust_remote_code", None)
 
-        def _do_download():
+        def _do_download(path_override: str | None = None):
             if isinstance(self.config.custom_dataset, Callable):
                 eval_logger.warning(
                     f"{self.config.task}: Custom kwargs can be passed to `--metadata` in console (as json string) or to the TaskManager."
@@ -874,9 +904,25 @@ class ConfigurableTask(Task):
                 )
             else:
                 return datasets.load_dataset(
-                    path=self.DATASET_PATH,
+                    path=path_override or self.DATASET_PATH,
                     name=self.DATASET_NAME,
                     **dataset_kwargs if dataset_kwargs is not None else {},
+                )
+
+        private_dataset_path = _resolve_private_dataset_path(self.DATASET_PATH)
+        if private_dataset_path is not None:
+            try:
+                self.dataset = _do_download(path_override=private_dataset_path)
+                eval_logger.info(
+                    f"Loaded task '{self.config.task}' from private dataset path: "
+                    f"{private_dataset_path} (source id: {self.DATASET_PATH})."
+                )
+                return
+            except Exception as e:
+                eval_logger.warning(
+                    f"Failed loading private dataset for task '{self.config.task}' "
+                    f"from '{private_dataset_path}' ({type(e).__name__}: {e}). "
+                    f"Falling back to '{self.DATASET_PATH}'."
                 )
 
         max_retries = 5

--- a/lm_eval/api/task.py
+++ b/lm_eval/api/task.py
@@ -88,6 +88,32 @@ def _resolve_private_dataset_path(dataset_path: str | None) -> str | None:
     return None
 
 
+def _is_saved_dataset_dir(path: Path) -> bool:
+    if not path.is_dir():
+        return False
+    # `datasets.save_to_disk` writes one of these at the root.
+    return (path / "dataset_dict.json").is_file() or (path / "dataset_info.json").is_file()
+
+
+def _resolve_private_saved_dataset_path(
+    private_dataset_root: str, dataset_name: str | None
+) -> str | None:
+    root = Path(private_dataset_root)
+
+    # Common mirror layout for configured datasets:
+    # <private-root>/<dataset-id>/<config>/dataset_dict.json
+    if dataset_name:
+        config_dir = root / dataset_name
+        if _is_saved_dataset_dir(config_dir):
+            return str(config_dir)
+
+    # Also support direct save_to_disk at the dataset root.
+    if _is_saved_dataset_dir(root):
+        return str(root)
+
+    return None
+
+
 TaskConfig = TaskConfig
 
 
@@ -912,6 +938,18 @@ class ConfigurableTask(Task):
         private_dataset_path = _resolve_private_dataset_path(self.DATASET_PATH)
         if private_dataset_path is not None:
             try:
+                saved_dataset_path = _resolve_private_saved_dataset_path(
+                    private_dataset_root=private_dataset_path,
+                    dataset_name=self.DATASET_NAME,
+                )
+                if saved_dataset_path is not None:
+                    self.dataset = datasets.load_from_disk(saved_dataset_path)
+                    eval_logger.info(
+                        f"Loaded task '{self.config.task}' from private saved dataset path: "
+                        f"{saved_dataset_path} (source id: {self.DATASET_PATH})."
+                    )
+                    return
+
                 self.dataset = _do_download(path_override=private_dataset_path)
                 eval_logger.info(
                     f"Loaded task '{self.config.task}' from private dataset path: "

--- a/lm_eval/loggers/wandb_logger.py
+++ b/lm_eval/loggers/wandb_logger.py
@@ -1,7 +1,7 @@
 import copy
 import json
 import logging
-from typing import Any, Literal, Tuple
+from typing import Any, Literal
 
 import numpy as np
 import pandas as pd
@@ -94,7 +94,7 @@ class WandbLogger:
 
         return configs
 
-    def _sanitize_results_dict(self) -> Tuple[dict[str, str], dict[str, Any]]:
+    def _sanitize_results_dict(self) -> tuple[dict[str, str], dict[str, Any]]:
         """Sanitize the results dictionary."""
         _results = copy.deepcopy(self.results.get("results", dict()))
 

--- a/lm_eval/loggers/wandb_logger.py
+++ b/lm_eval/loggers/wandb_logger.py
@@ -1,7 +1,7 @@
 import copy
 import json
 import logging
-from typing import Any, Dict, List, Literal, Tuple
+from typing import Any, Literal, Tuple
 
 import numpy as np
 import pandas as pd
@@ -31,8 +31,8 @@ class WandbLogger:
         """Attaches to wandb logger if already initialized. Otherwise, passes init_args to wandb.init() and config_args to wandb.config.update()
 
         Args:
-            init_args Optional[Dict]: Arguments for init configuration.
-            config_args Optional[Dict]: Arguments for config
+            init_args Optional[dict]: Arguments for init configuration.
+            config_args Optional[dict]: Arguments for config
 
         Parse and log the results returned from evaluator.simple_evaluate() with:
             wandb_logger.post_init(results)
@@ -52,8 +52,8 @@ class WandbLogger:
                 f"{e}"
             )
 
-        self.wandb_args: Dict[str, Any] = init_args or {}
-        self.wandb_config_args: Dict[str, Any] = config_args or {}
+        self.wandb_args: dict[str, Any] = init_args or {}
+        self.wandb_config_args: dict[str, Any] = config_args or {}
 
         # pop the step key from the args to save for all logging calls
         self.step = self.wandb_args.pop("step", None)
@@ -78,12 +78,12 @@ class WandbLogger:
 
         self.printer = get_wandb_printer()
 
-    def post_init(self, results: Dict[str, Any]) -> None:
-        self.results: Dict[str, Any] = copy.deepcopy(results)
-        self.task_names: List[str] = list(results.get("results", {}).keys())
-        self.group_names: List[str] = list(results.get("groups", {}).keys())
+    def post_init(self, results: dict[str, Any]) -> None:
+        self.results: dict[str, Any] = copy.deepcopy(results)
+        self.task_names: list[str] = list(results.get("results", {}).keys())
+        self.group_names: list[str] = list(results.get("groups", {}).keys())
 
-    def _get_config(self) -> Dict[str, Any]:
+    def _get_config(self) -> dict[str, Any]:
         """Get configuration parameters."""
         self.task_configs = self.results.get("configs", {})
         cli_configs = self.results.get("config", {})
@@ -94,7 +94,7 @@ class WandbLogger:
 
         return configs
 
-    def _sanitize_results_dict(self) -> Tuple[Dict[str, str], Dict[str, Any]]:
+    def _sanitize_results_dict(self) -> Tuple[dict[str, str], dict[str, Any]]:
         """Sanitize the results dictionary."""
         _results = copy.deepcopy(self.results.get("results", dict()))
 
@@ -141,7 +141,7 @@ class WandbLogger:
             "Stderr",
         ]
 
-        def make_table(columns: List[str], key: str = "results"):
+        def make_table(columns: list[str], key: str = "results"):
             import wandb
 
             table = wandb.Table(columns=columns)
@@ -214,13 +214,13 @@ class WandbLogger:
         self._log_results_as_artifact()
 
     def _generate_dataset(
-        self, data: List[Dict[str, Any]], config: Dict[str, Any]
+        self, data: list[dict[str, Any]], config: dict[str, Any]
     ) -> pd.DataFrame:
         """Generate a dataset from evaluation data.
 
         Args:
-            data (List[Dict[str, Any]]): The data to generate a dataset for.
-            config (Dict[str, Any]): The configuration of the task.
+            data (list[dict[str, Any]]): The data to generate a dataset for.
+            config (dict[str, Any]): The configuration of the task.
 
         Returns:
             pd.DataFrame: A dataframe that is ready to be uploaded to W&B.
@@ -305,7 +305,7 @@ class WandbLogger:
         return pd.DataFrame(df_data)
 
     def _log_samples_as_artifact(
-        self, data: List[Dict[str, Any]], task_name: str
+        self, data: list[dict[str, Any]], task_name: str
     ) -> None:
         import wandb
 
@@ -329,13 +329,13 @@ class WandbLogger:
         dataset_path = task_config.get("dataset_path")
         return dataset_path in _WANDB_SAMPLES_BLOCKED_DATASET_PATHS
 
-    def log_eval_samples(self, samples: Dict[str, List[Dict[str, Any]]]) -> None:
+    def log_eval_samples(self, samples: dict[str, list[dict[str, Any]]]) -> None:
         """Log evaluation samples to W&B.
 
         Args:
-            samples (Dict[str, List[Dict[str, Any]]]): Evaluation samples for each task.
+            samples (dict[str, list[dict[str, Any]]]): Evaluation samples for each task.
         """
-        task_names: List[str] = [
+        task_names: list[str] = [
             x for x in self.task_names if x not in self.group_names
         ]
 

--- a/lm_eval/loggers/wandb_logger.py
+++ b/lm_eval/loggers/wandb_logger.py
@@ -12,6 +12,11 @@ from lm_eval.loggers.utils import _handle_non_serializable, remove_none_pattern
 
 logger = logging.getLogger(__name__)
 
+_WANDB_SAMPLES_BLOCKED_DATASET_PATHS = {
+    "swiss-ai/switzerland_qa",
+    "swiss-ai/include-base-new-45",
+}
+
 
 def get_wandb_printer() -> Literal["Printer"]:
     """Returns a wandb printer instance for pretty stdout."""
@@ -319,6 +324,11 @@ class WandbLogger:
         self.run.log_artifact(artifact)
         # artifact.wait()
 
+    def _should_skip_samples_upload(self, task_name: str) -> bool:
+        task_config = self.task_configs.get(task_name, {})
+        dataset_path = task_config.get("dataset_path")
+        return dataset_path in _WANDB_SAMPLES_BLOCKED_DATASET_PATHS
+
     def log_eval_samples(self, samples: Dict[str, List[Dict[str, Any]]]) -> None:
         """Log evaluation samples to W&B.
 
@@ -347,6 +357,13 @@ class WandbLogger:
                 ungrouped_tasks.append(task_name)
 
         for task_name in ungrouped_tasks:
+            if self._should_skip_samples_upload(task_name):
+                logger.info(
+                    f"Skipping W&B sample upload for private dataset task '{task_name}'."
+                )
+                continue
+            if task_name not in samples:
+                continue
             eval_preds = samples[task_name]
 
             # log the samples as a W&B Table
@@ -361,6 +378,14 @@ class WandbLogger:
         for group, grouped_tasks in tasks_by_groups.items():
             grouped_df = pd.DataFrame()
             for task_name in grouped_tasks:
+                if self._should_skip_samples_upload(task_name):
+                    logger.info(
+                        f"Skipping W&B sample upload for private dataset task "
+                        f"'{task_name}' in group '{group}'."
+                    )
+                    continue
+                if task_name not in samples:
+                    continue
                 eval_preds = samples[task_name]
                 df = self._generate_dataset(
                     eval_preds, self.task_configs.get(task_name)
@@ -372,6 +397,8 @@ class WandbLogger:
                 # log the samples as a json file as W&B Artifact
                 self._log_samples_as_artifact(eval_preds, task_name)
 
-            self.run.log(
-                {f"{group}_eval_results": grouped_df, **self.step_metrics}, commit=True
-            )
+            if not grouped_df.empty:
+                self.run.log(
+                    {f"{group}_eval_results": grouped_df, **self.step_metrics},
+                    commit=True,
+                )

--- a/lm_eval/loggers/wandb_logger.py
+++ b/lm_eval/loggers/wandb_logger.py
@@ -116,7 +116,7 @@ class WandbLogger:
                 if isinstance(metric_value, str):
                     wandb_summary[f"{task}/{metric_name}"] = metric_value
 
-        for summary_metric, summary_value in wandb_summary.items():
+        for summary_metric, _summary_value in wandb_summary.items():
             _task, _summary_metric = summary_metric.split("/")
             _results[_task].pop(_summary_metric)
 
@@ -148,7 +148,7 @@ class WandbLogger:
             results = copy.deepcopy(self.results)
 
             for k, dic in results.get(key).items():
-                if k in self.group_names and not key == "groups":
+                if k in self.group_names and key != "groups":
                     continue
                 version = results.get("versions").get(k)
                 if version == "N/A":
@@ -165,7 +165,7 @@ class WandbLogger:
                     if m + "_stderr" + "," + f in dic:
                         se = dic[m + "_stderr" + "," + f]
                         if se != "N/A":
-                            se = "%.4f" % se
+                            se = f"{se:.4f}"
                         table.add_data(*[k, version, f, n, m, str(v), str(se)])
                     else:
                         table.add_data(*[k, version, f, n, m, str(v), ""])
@@ -274,11 +274,7 @@ class WandbLogger:
             filtered_resps = [
                 np.argmax([n[0] for n in x["filtered_resps"]]) for x in data
             ]
-        elif config["output_type"] == "loglikelihood_rolling":
-            instance = [x["arguments"][0][0] for x in data]
-            resps = [x["resps"][0][0] for x in data]
-            filtered_resps = [x["filtered_resps"][0] for x in data]
-        elif config["output_type"] == "generate_until":
+        elif config["output_type"] in {"loglikelihood_rolling", "generate_until"}:
             instance = [x["arguments"][0][0] for x in data]
             resps = [x["resps"][0][0] for x in data]
             filtered_resps = [x["filtered_resps"][0] for x in data]

--- a/tests/test_evaluator.py
+++ b/tests/test_evaluator.py
@@ -1,7 +1,6 @@
 import os
 import re
 from math import isclose
-from typing import List
 
 import pytest
 
@@ -37,7 +36,7 @@ os.environ["TOKENIZERS_PARALLELISM"] = "false"
     ids=lambda d: f"{d}",
 )
 def test_evaluator(
-    task_name: List[str], limit: int, model: str, model_args: str, bootstrap_iters: int
+    task_name: list[str], limit: int, model: str, model_args: str, bootstrap_iters: int
 ):
     e1 = evaluator.simple_evaluate(
         model=model,
@@ -77,7 +76,11 @@ def test_evaluator(
 
     assert all(
         x == y
-        for x, y in zip([y for _, y in r(e1).items()], [y for _, y in r(e2).items()])
+        for x, y in zip(
+            [y for _, y in r(e1).items()],
+            [y for _, y in r(e2).items()],
+            strict=True,
+        )
     )
 
 
@@ -111,7 +114,7 @@ def test_evaluator(
     ],
     ids=lambda d: f"{d}",
 )
-def test_printed_results(task_name: List[str], limit: int, model: str, model_args: str):
+def test_printed_results(task_name: list[str], limit: int, model: str, model_args: str):
     results = evaluator.simple_evaluate(
         model=model,
         tasks=task_name,
@@ -133,18 +136,18 @@ def test_printed_results(task_name: List[str], limit: int, model: str, model_arg
         )
     )
     filepath = f"./tests/testdata/{filename}.txt"
-    with open(filepath, "r") as f:
+    with open(filepath) as f:
         t1 = f.read().strip()
 
     t2 = make_table(results).strip()
 
     t1_lines, t2_lines = t1.splitlines(), t2.splitlines()
     assert len(t1_lines) == len(t2_lines)
-    for t1_line, t2_line in zip(t1_lines, t2_lines):
+    for t1_line, t2_line in zip(t1_lines, t2_lines, strict=True):
         t1_items, t2_items = t1_line.split("|"), t2_line.split("|")
         assert len(t1_items) == len(t2_items)
         metric_name = t1_items[5].strip() if len(t1_items) > 5 else ""
-        for t1_item, t2_item in zip(t1_items, t2_items):
+        for t1_item, t2_item in zip(t1_items, t2_items, strict=True):
             try:
                 t1_item_f = float(t1_item)
                 t2_item_f = float(t2_item)

--- a/tests/test_evaluator.py
+++ b/tests/test_evaluator.py
@@ -1,5 +1,6 @@
 import os
 import re
+from math import isclose
 from typing import List
 
 import pytest
@@ -142,10 +143,14 @@ def test_printed_results(task_name: List[str], limit: int, model: str, model_arg
     for t1_line, t2_line in zip(t1_lines, t2_lines):
         t1_items, t2_items = t1_line.split("|"), t2_line.split("|")
         assert len(t1_items) == len(t2_items)
+        metric_name = t1_items[5].strip() if len(t1_items) > 5 else ""
         for t1_item, t2_item in zip(t1_items, t2_items):
             try:
-                t1_item = float(t1_item)
-                t2_item = float(t2_item)
-                assert abs(t1_item - t2_item) < 0.3
+                t1_item_f = float(t1_item)
+                t2_item_f = float(t2_item)
+                if metric_name in {"perplexity", "word_perplexity", "byte_perplexity"}:
+                    assert isclose(t1_item_f, t2_item_f, rel_tol=0.8, abs_tol=0.0)
+                else:
+                    assert abs(t1_item_f - t2_item_f) < 0.3
             except ValueError:
                 assert t1_item == t2_item

--- a/tests/test_private_dataset_overrides.py
+++ b/tests/test_private_dataset_overrides.py
@@ -1,0 +1,76 @@
+from types import SimpleNamespace
+from unittest.mock import Mock
+
+import pytest
+
+from lm_eval.api.task import ConfigurableTask
+
+
+def _make_task(dataset_path: str, dataset_name: str = "English") -> ConfigurableTask:
+    task = object.__new__(ConfigurableTask)
+    task.DATASET_PATH = dataset_path
+    task.DATASET_NAME = dataset_name
+    task._config = SimpleNamespace(
+        custom_dataset=None,
+        metadata=None,
+        dataset_kwargs=None,
+        task="dummy_task",
+    )
+    return task
+
+
+@pytest.mark.parametrize(
+    ("dataset_path", "private_dir_name"),
+    [
+        ("swiss-ai/switzerland_qa", "swiss-ai__switzerland_qa"),
+        ("swiss-ai/include-base-new-45", "swiss-ai__include-base-new-45"),
+    ],
+)
+def test_private_dataset_uses_local_path_when_present(
+    monkeypatch, tmp_path, dataset_path: str, private_dir_name: str
+):
+    local_root = tmp_path
+    local_path = local_root / private_dir_name
+    local_path.mkdir(parents=True)
+
+    loader = Mock(return_value={"ok": True})
+    monkeypatch.setenv("LM_EVAL_PRIVATE_DATASET_ROOT", str(local_root))
+    monkeypatch.setattr("lm_eval.api.task.datasets.load_dataset", loader)
+
+    task = _make_task(dataset_path=dataset_path)
+    task.download({})
+
+    assert task.dataset == {"ok": True}
+    assert loader.call_count == 1
+    assert loader.call_args.kwargs["path"] == str(local_path)
+    assert loader.call_args.kwargs["name"] == "English"
+
+
+def test_private_dataset_falls_back_to_hf_when_missing(monkeypatch, tmp_path):
+    loader = Mock(return_value={"ok": True})
+    monkeypatch.setenv("LM_EVAL_PRIVATE_DATASET_ROOT", str(tmp_path))
+    monkeypatch.setattr("lm_eval.api.task.datasets.load_dataset", loader)
+
+    task = _make_task(dataset_path="swiss-ai/switzerland_qa")
+    task.download({})
+
+    assert task.dataset == {"ok": True}
+    assert loader.call_count == 1
+    assert loader.call_args.kwargs["path"] == "swiss-ai/switzerland_qa"
+
+
+def test_private_dataset_falls_back_to_hf_when_local_load_fails(monkeypatch, tmp_path):
+    local_path = tmp_path / "swiss-ai__switzerland_qa"
+    local_path.mkdir(parents=True)
+
+    loader = Mock(side_effect=[RuntimeError("bad local dataset"), {"ok": True}])
+    monkeypatch.setenv("LM_EVAL_PRIVATE_DATASET_ROOT", str(tmp_path))
+    monkeypatch.setattr("lm_eval.api.task.datasets.load_dataset", loader)
+
+    task = _make_task(dataset_path="swiss-ai/switzerland_qa")
+    task.download({})
+
+    assert task.dataset == {"ok": True}
+    assert loader.call_count == 2
+    assert loader.call_args_list[0].kwargs["path"] == str(local_path)
+    assert loader.call_args_list[1].kwargs["path"] == "swiss-ai/switzerland_qa"

--- a/tests/test_private_dataset_overrides.py
+++ b/tests/test_private_dataset_overrides.py
@@ -74,3 +74,23 @@ def test_private_dataset_falls_back_to_hf_when_local_load_fails(monkeypatch, tmp
     assert loader.call_count == 2
     assert loader.call_args_list[0].kwargs["path"] == str(local_path)
     assert loader.call_args_list[1].kwargs["path"] == "swiss-ai/switzerland_qa"
+
+
+def test_private_dataset_loads_from_saved_dataset_config_dir(monkeypatch, tmp_path):
+    local_path = tmp_path / "swiss-ai__switzerland_qa"
+    config_path = local_path / "Romansh"
+    config_path.mkdir(parents=True)
+    (config_path / "dataset_dict.json").write_text("{}", encoding="utf-8")
+
+    load_from_disk = Mock(return_value={"ok": "from-disk"})
+    load_dataset = Mock()
+    monkeypatch.setenv("LM_EVAL_PRIVATE_DATASET_ROOT", str(tmp_path))
+    monkeypatch.setattr("lm_eval.api.task.datasets.load_from_disk", load_from_disk)
+    monkeypatch.setattr("lm_eval.api.task.datasets.load_dataset", load_dataset)
+
+    task = _make_task(dataset_path="swiss-ai/switzerland_qa", dataset_name="Romansh")
+    task.download({})
+
+    assert task.dataset == {"ok": "from-disk"}
+    load_from_disk.assert_called_once_with(str(config_path))
+    load_dataset.assert_not_called()

--- a/tests/test_wandb_private_samples.py
+++ b/tests/test_wandb_private_samples.py
@@ -1,0 +1,109 @@
+from unittest.mock import Mock
+
+import pandas as pd
+
+from lm_eval.loggers.wandb_logger import WandbLogger
+
+
+def _make_logger(task_configs, task_names):
+    logger = object.__new__(WandbLogger)
+    logger.task_configs = task_configs
+    logger.task_names = task_names
+    logger.group_names = []
+    logger.step_metrics = {"OptimizerStep": 1}
+    logger.run = Mock()
+    logger._generate_dataset = Mock(return_value=pd.DataFrame([{"id": 1}]))
+    logger._log_samples_as_artifact = Mock()
+    return logger
+
+
+def test_log_eval_samples_skips_private_dataset_tasks():
+    logger = _make_logger(
+        task_configs={
+            "private_task": {"dataset_path": "swiss-ai/switzerland_qa"},
+            "public_task": {"dataset_path": "hellaswag"},
+        },
+        task_names=["private_task", "public_task"],
+    )
+
+    samples = {
+        "private_task": [
+            {
+                "doc_id": 0,
+                "target": "A",
+                "arguments": [["q"]],
+                "resps": [[["a"]]],
+                "filtered_resps": [["a"]],
+                "acc": 1.0,
+            }
+        ],
+        "public_task": [
+            {
+                "doc_id": 1,
+                "target": "B",
+                "arguments": [["q"]],
+                "resps": [[["b"]]],
+                "filtered_resps": [["b"]],
+                "acc": 1.0,
+            }
+        ],
+    }
+
+    logger.log_eval_samples(samples)
+
+    assert logger._generate_dataset.call_count == 1
+    assert logger._generate_dataset.call_args.args[0] == samples["public_task"]
+    logger._log_samples_as_artifact.assert_called_once_with(
+        samples["public_task"], "public_task"
+    )
+    assert logger.run.log.call_count == 1
+    logged_payload = logger.run.log.call_args.kwargs
+    assert logged_payload["commit"] is True
+    assert "public_task_eval_results" in logger.run.log.call_args.args[0]
+    assert "private_task_eval_results" not in logger.run.log.call_args.args[0]
+
+
+def test_log_eval_samples_grouped_tasks_skip_private_and_keep_public():
+    logger = _make_logger(
+        task_configs={
+            "private_group_task": {
+                "dataset_path": "swiss-ai/include-base-new-45",
+                "group": "my_group",
+            },
+            "public_group_task": {"dataset_path": "hellaswag", "group": "my_group"},
+        },
+        task_names=["private_group_task", "public_group_task"],
+    )
+
+    samples = {
+        "private_group_task": [
+            {
+                "doc_id": 0,
+                "target": "A",
+                "arguments": [["q"]],
+                "resps": [[["a"]]],
+                "filtered_resps": [["a"]],
+                "acc": 1.0,
+            }
+        ],
+        "public_group_task": [
+            {
+                "doc_id": 1,
+                "target": "B",
+                "arguments": [["q"]],
+                "resps": [[["b"]]],
+                "filtered_resps": [["b"]],
+                "acc": 1.0,
+            }
+        ],
+    }
+
+    logger.log_eval_samples(samples)
+
+    assert logger._generate_dataset.call_count == 1
+    assert logger._generate_dataset.call_args.args[0] == samples["public_group_task"]
+    logger._log_samples_as_artifact.assert_called_once_with(
+        samples["public_group_task"], "public_group_task"
+    )
+    assert logger.run.log.call_count == 1
+    assert "my_group_eval_results" in logger.run.log.call_args.args[0]


### PR DESCRIPTION
For datasets marked as private, first check file system for saved benchmark data, falls back to Huggingface lookup if not available. 

Also disables uploading of private dataset samples to W&B to avoid accidental leakage of data.