### PR TITLE
Add answer and thinking length tracking

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 ---
 
 ## Latest News 📣
-- [2026/06] **Generation length & thinking-format metrics**: `generate_until` backends now record per-response response/thinking length and reasoning-block well-formedness (`thinking_format_has_open/has_close/correct`). Thinking-format aggregates to per-task metrics natively; add `--log_length_metrics` to also aggregate length. See the [CLI Reference](./docs/interface.md#generation-length--thinking-format-metrics).
+- [2026/06] **Generation length & thinking-format metrics**: `generate_until` backends now record per-response response/thinking length and reasoning-block well-formedness (`thinking_format_has_open/has_close/correct`). Thinking-format aggregates to per-task metrics natively; add `--log_length_metrics` to also aggregate length. See [Thinking / Reasoning Evals](./docs/thinking_evals.md).
 - [2025/12] **CLI refactored** with subcommands (`run`, `ls`, `validate`) and YAML config file support via `--config`. See the [CLI Reference](./docs/interface.md) and [Configuration Guide](./docs/config_files.md).
 - [2025/12] **Lighter install**: Base package no longer includes `transformers`/`torch`. Install model backends separately: `pip install lm_eval[hf]`, `lm_eval[vllm]`, etc.
 - [2025/07] Added `think_end_token` arg to `hf` (token/str), `vllm` and `sglang` (str) for stripping CoT reasoning traces from models that support it.

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 ---
 
 ## Latest News 📣
-- [2026/06] **Generation length & thinking-format metrics**: `generate_until` backends now record per-response response/thinking length and reasoning-block well-formedness (`thinking_format_has_open/has_close/correct`). Thinking-format aggregates to per-task metrics natively; add `--log_length_metrics` to also aggregate length. See [Thinking / Reasoning Evals](./docs/thinking_evals.md).
+- [2026/06] **Generation length & thinking-format metrics**: `generate_until` backends now record per-response response/thinking length and reasoning-block well-formedness (`thinking_format_has_open/has_close/correct`). Thinking-format aggregates to per-task metrics natively; add `--log_length_metrics` to also aggregate length. The reasoning machinery is **opt-in**: the strip runs only when a `think_end_token` is known — pass it explicitly, or set `autodetect_think_tokens=true` to read it from the chat template. `enable_thinking` is a chat-template argument only and gates none of this. See [Thinking / Reasoning Evals](./docs/thinking_evals.md).
 - [2025/12] **CLI refactored** with subcommands (`run`, `ls`, `validate`) and YAML config file support via `--config`. See the [CLI Reference](./docs/interface.md) and [Configuration Guide](./docs/config_files.md).
 - [2025/12] **Lighter install**: Base package no longer includes `transformers`/`torch`. Install model backends separately: `pip install lm_eval[hf]`, `lm_eval[vllm]`, etc.
 - [2025/07] Added `think_end_token` arg to `hf` (token/str), `vllm` and `sglang` (str) for stripping CoT reasoning traces from models that support it.

--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@
 ---
 
 ## Latest News 📣
+- [2026/06] **Generation length & thinking-format metrics**: `generate_until` backends now record per-response response/thinking length and reasoning-block well-formedness (`thinking_format_has_open/has_close/correct`). Thinking-format aggregates to per-task metrics natively; add `--log_length_metrics` to also aggregate length. See the [CLI Reference](./docs/interface.md#generation-length--thinking-format-metrics).
 - [2025/12] **CLI refactored** with subcommands (`run`, `ls`, `validate`) and YAML config file support via `--config`. See the [CLI Reference](./docs/interface.md) and [Configuration Guide](./docs/config_files.md).
 - [2025/12] **Lighter install**: Base package no longer includes `transformers`/`torch`. Install model backends separately: `pip install lm_eval[hf]`, `lm_eval[vllm]`, etc.
 - [2025/07] Added `think_end_token` arg to `hf` (token/str), `vllm` and `sglang` (str) for stripping CoT reasoning traces from models that support it.

--- a/docs/README.md
+++ b/docs/README.md
@@ -9,3 +9,4 @@ Welcome to the docs for the LM Evaluation Harness!
   * For an extended description of how to extend the library to new model classes served over an API, see the [API Guide](./API_guide.md).
 * For a crash course on adding new tasks to the library, see our [New Task Guide](./new_task_guide.md).
 * To learn more about pushing the limits of task configuration that the Eval Harness supports, see the [Task Configuration Guide](./task_guide.md).
+* To learn how reasoning ("thinking") models are handled — the reasoning-trace strip and the per-response length / thinking-format metrics — see the [Thinking / Reasoning Evals](./thinking_evals.md) guide.

--- a/docs/interface.md
+++ b/docs/interface.md
@@ -99,6 +99,7 @@ lm-eval run --config my_config.yaml --tasks mmlu
 | `--output_path` | `-o` | Output directory or JSON file for results. Required with `--log_samples`. |
 | `--log_samples` | `-s` | Save all model inputs/outputs for post-hoc analysis. |
 | `--samples` | `-E` | JSON mapping task names to sample indices, e.g., `'{"task1": [0,1,2]}'`. Incompatible with `--limit`. |
+| `--log_length_metrics` | | Aggregate per-response response/thinking length into per-task metrics in the results and W&B. See [Generation length & thinking-format metrics](#generation-length--thinking-format-metrics). |
 
 ### Caching and Performance
 
@@ -162,6 +163,50 @@ The `--hf_hub_log_args` argument accepts these keys:
 | `leaderboard_url` | URL to associated leaderboard. |
 | `point_of_contact` | Contact email for results dataset. |
 | `gated` | `True`/`False` - gate the details dataset. |
+
+---
+
+### Generation length & thinking-format metrics
+
+For `generate_until` (and `multi_turn_generate`) tasks, the `hf`, `vllm`, and
+`sglang` backends measure each response on the **raw generation, before the
+reasoning trace is stripped**, and record it per response in the sample's
+`length_info` field (visible with `--log_samples`). Two families are produced:
+
+**Length** (`response_length_*`) — always measured; the `thinking_length_*` pair
+is added only when the response contains the reasoning close token:
+
+| Metric | Meaning |
+|--------|---------|
+| `response_length_words` / `_chars` / `_tokens` | Length of the full generation (reasoning + answer). `_tokens` uses the exact generated token ids when the backend provides them. |
+| `thinking_length_words` / `_chars` / `_tokens` | Length of the reasoning span (start of generation up to and including the close token). Only present when the model actually closed a think block. |
+
+**Thinking-format** (`thinking_format_*`, 0/1 per response) — a well-formedness
+signal for reasoning models:
+
+| Metric | Meaning |
+|--------|---------|
+| `thinking_format_has_open` | The reasoning open token is present in the prompt **or** generation (thinking templates usually prefill the open into the prompt). |
+| `thinking_format_has_close` | The reasoning close token is present in the generation (the model emitted it). |
+| `thinking_format_correct` | Open present, close present, open precedes close, and the block is not re-opened after the close. |
+
+The open/close tokens are auto-detected from the model's chat template
+(`inner_token` / `outer_token` declarations), or set explicitly with the
+`think_start_token` / `think_end_token` **model args**. The close token is also
+what the harness strips before answer extraction; if thinking is enabled but the
+close token cannot be resolved, model construction fails loudly (pass the tokens
+explicitly, or set `enable_thinking=false`).
+
+**Native per-task aggregation.** By default these stay per-sample (in the logged
+samples / jsonl). Pass `--log_length_metrics` to additionally aggregate the
+**length** metrics into per-task numbers in `results.json`, the printed table,
+and W&B (a per-task mean over documents). The `thinking_format_*` metrics are
+**always** aggregated this way (no flag needed). Aggregated keys appear under the
+`none` filter, e.g. `gsm8k/thinking_format_correct,none`.
+
+Caveats: `has_open`/`correct` can over-count under **few-shot** (demo think tags
+in the prompt) and **multi-turn** (a prior turn's unclosed open leaks into the
+next turn's history). For aggregated W&B/per-task upload, pass `--wandb_args`.
 
 ---
 

--- a/docs/interface.md
+++ b/docs/interface.md
@@ -168,45 +168,27 @@ The `--hf_hub_log_args` argument accepts these keys:
 
 ### Generation length & thinking-format metrics
 
-For `generate_until` (and `multi_turn_generate`) tasks, the `hf`, `vllm`, and
-`sglang` backends measure each response on the **raw generation, before the
-reasoning trace is stripped**, and record it per response in the sample's
-`length_info` field (visible with `--log_samples`). Two families are produced:
+Options that control the per-response length / thinking-format metrics and the
+reasoning-trace strip for thinking models. See **[Thinking / reasoning
+evals](./thinking_evals.md)** for what these metrics mean, what is logged where,
+malformed/non-thinking handling, and multi-turn behavior.
 
-**Length** (`response_length_*`) — always measured; the `thinking_length_*` pair
-is added only when the response contains the reasoning close token:
+Added by this feature:
 
-| Metric | Meaning |
-|--------|---------|
-| `response_length_words` / `_chars` / `_tokens` | Length of the full generation (reasoning + answer). `_tokens` uses the exact generated token ids when the backend provides them. |
-| `thinking_length_words` / `_chars` / `_tokens` | Length of the reasoning span (start of generation up to and including the close token). Only present when the model actually closed a think block. |
+| Option | Kind | Description |
+|--------|------|-------------|
+| `--log_length_metrics` | CLI | Aggregate `response_length_*` / `thinking_length_*` into per-task metrics (results.json, table, W&B). Off by default; `thinking_format_*` is aggregated regardless. |
+| `think_start_token` | `--model_args` | Force the reasoning **open** token (str); else auto-detected from the chat template. |
 
-**Thinking-format** (`thinking_format_*`, 0/1 per response) — a well-formedness
-signal for reasoning models:
+Pre-existing options that also affect these metrics:
 
-| Metric | Meaning |
-|--------|---------|
-| `thinking_format_has_open` | The reasoning open token is present in the prompt **or** generation (thinking templates usually prefill the open into the prompt). |
-| `thinking_format_has_close` | The reasoning close token is present in the generation (the model emitted it). |
-| `thinking_format_correct` | Open present, close present, open precedes close, and the block is not re-opened after the close. |
-
-The open/close tokens are auto-detected from the model's chat template
-(`inner_token` / `outer_token` declarations), or set explicitly with the
-`think_start_token` / `think_end_token` **model args**. The close token is also
-what the harness strips before answer extraction; if thinking is enabled but the
-close token cannot be resolved, model construction fails loudly (pass the tokens
-explicitly, or set `enable_thinking=false`).
-
-**Native per-task aggregation.** By default these stay per-sample (in the logged
-samples / jsonl). Pass `--log_length_metrics` to additionally aggregate the
-**length** metrics into per-task numbers in `results.json`, the printed table,
-and W&B (a per-task mean over documents). The `thinking_format_*` metrics are
-**always** aggregated this way (no flag needed). Aggregated keys appear under the
-`none` filter, e.g. `gsm8k/thinking_format_correct,none`.
-
-Caveats: `has_open`/`correct` can over-count under **few-shot** (demo think tags
-in the prompt) and **multi-turn** (a prior turn's unclosed open leaks into the
-next turn's history). For aggregated W&B/per-task upload, pass `--wandb_args`.
+| Option | Kind | Description |
+|--------|------|-------------|
+| `--log_samples` | CLI | Write the per-response `length_info` (all length + thinking-format fields) into the sample jsonl. |
+| `--wandb_args` | CLI (value) | Native W&B upload of the aggregated metrics, e.g. `--wandb_args project=p name=run1`. |
+| `--apply_chat_template` | CLI | Required for the chat/thinking template to render (the reasoning tokens live in it). |
+| `enable_thinking` | `--model_args` | `true`/`false` — model reasoning mode (`vllm`/`hf`). On `hf` the fail-loud close-token guard defaults on. |
+| `think_end_token` | `--model_args` | Force the reasoning **close** token (str; also int token id on `hf`); drives the strip; else auto-detected. |
 
 ---
 

--- a/docs/interface.md
+++ b/docs/interface.md
@@ -173,12 +173,36 @@ reasoning-trace strip for thinking models. See **[Thinking / reasoning
 evals](./thinking_evals.md)** for what these metrics mean, what is logged where,
 malformed/non-thinking handling, and multi-turn behavior.
 
+**Overview — four independent switches:**
+
+- **The model thinks** when its **chat template** says so. `enable_thinking` is purely a
+  template argument: `vllm` forwards it (default `true`), `hf` forwards it only when you
+  set it explicitly, and `sglang` never does — otherwise the template's own default
+  applies. It does **not** gate the strip, token detection, or metric tracking.
+- **The reasoning tokens are auto-detected** from the chat template only when you opt in
+  with `autodetect_think_tokens=true` (default `false`, so nothing is scanned).
+- **The strip runs** whenever a reasoning **close** token is known — set explicitly via
+  `think_end_token`, or auto-detected. Everything up to and including the close is
+  dropped before the answer is scored. By default no close is known, so **nothing is
+  stripped**.
+- **Thinking length & correctness** (`thinking_length_*`, `thinking_format_*`) are
+  tracked iff a close token is known — or whatever `track_thinking_metrics` forces.
+  `thinking_format_*` reaches results/W&B on its own; `thinking_length_*` needs
+  `--log_length_metrics`.
+- **Response length** (`response_length_*`) is recorded for **every** `generate_until`
+  response, thinking or not, and reaches results/W&B with `--log_length_metrics`.
+
+Per-response values are always written to `length_info` in the sample jsonl under
+`--log_samples`, independently of the aggregation flags.
+
 Added by this feature:
 
 | Option | Kind | Description |
 |--------|------|-------------|
 | `--log_length_metrics` | CLI | Aggregate `response_length_*` / `thinking_length_*` into per-task metrics (results.json, table, W&B). Off by default; `thinking_format_*` is aggregated regardless. |
-| `think_start_token` | `--model_args` | Force the reasoning **open** token (str); else auto-detected from the chat template. |
+| `think_start_token` | `--model_args` | Force the reasoning **open** token (str); otherwise auto-detected from the chat template only when `autodetect_think_tokens=true`. Used for `thinking_format_has_open`; without it the format metric degrades to close-only. |
+| `autodetect_think_tokens` | `--model_args` | `true`/`false` (**default `false`**) — opt in to auto-detecting the reasoning open/close from the chat template. Left off, the template is never scanned: with no explicit `think_end_token` there is then **no strip and no thinking metrics**, and the fail-loud guard cannot fire. |
+| `track_thinking_metrics` | `--model_args` | `true`/`false` — force the `thinking_format_*` / `thinking_length_*` metrics on or off. Default (unset) derives them: on iff a close token is known. Requires a close token even when forced on (a missing **open** is fine — the metric degrades to close-only). `response_length_*` is unaffected. |
 
 Pre-existing options that also affect these metrics:
 
@@ -187,8 +211,24 @@ Pre-existing options that also affect these metrics:
 | `--log_samples` | CLI | Write the per-response `length_info` (all length + thinking-format fields) into the sample jsonl. |
 | `--wandb_args` | CLI (value) | Native W&B upload of the aggregated metrics, e.g. `--wandb_args project=p name=run1`. |
 | `--apply_chat_template` | CLI | Required for the chat/thinking template to render (the reasoning tokens live in it). |
-| `enable_thinking` | `--model_args` | `true`/`false` — model reasoning mode (`vllm`/`hf`). On `hf` the fail-loud close-token guard defaults on. |
-| `think_end_token` | `--model_args` | Force the reasoning **close** token (str; also int token id on `hf`); drives the strip; else auto-detected. |
+| `enable_thinking` | `--model_args` | `true`/`false` — a **chat-template argument only** (`hf`/`vllm`; `sglang` has none). Forwarded by `vllm` (default `true`) and by `hf` only when set explicitly; otherwise the template's default decides. It does **not** gate the strip, token detection, or metric tracking. (It changes the rendered prompt, so on a prefill template it does affect the `has_open` value.) |
+| `think_end_token` | `--model_args` | Force the reasoning **close** token (str; also int token id on `hf`); drives the strip. Honoured with or without `autodetect_think_tokens`. |
+
+Useful combinations:
+
+```bash
+# Nothing (the default): no detection, no strip, no thinking metrics
+--model_args pretrained=M
+
+# Opt in: detect the tokens, strip the trace, record the thinking metrics
+--model_args pretrained=M,autodetect_think_tokens=true
+
+# Name the close yourself (no template scan; `has_open` is not tracked)
+--model_args pretrained=M,think_end_token='</think>'
+
+# Strip, but drop the thinking metrics (and their per-response cost)
+--model_args pretrained=M,autodetect_think_tokens=true,track_thinking_metrics=false
+```
 
 ---
 

--- a/docs/thinking_evals.md
+++ b/docs/thinking_evals.md
@@ -24,9 +24,10 @@ up to and including the close token, so only the post-reasoning answer is scored
   model construction raises — pass `think_end_token=` explicitly, or set
   `enable_thinking=false`. This prevents silently scoring un-stripped reasoning.
   (On `hf` the guard defaults to enabled, so a reasoning-declaring template with an
-  unresolvable close raises even if you never set `enable_thinking`.) A missing
-  **open** token only warns — `has_open`/`correct` are then not tracked unless you
-  pass `think_start_token=`.
+  unresolvable close raises even if you never set `enable_thinking`. `sglang` has no
+  `enable_thinking` toggle — a reasoning-declaring template is always thinking-enabled.)
+  A missing **open** token only warns — `has_open` is then not tracked and `correct`
+  falls back to `has_close` (close-only style) unless you pass `think_start_token=`.
 
 > If the close token is wrong/unresolved, the reasoning is **not** stripped and
 > pollutes answer extraction. The metrics below (`thinking_format_has_close`,
@@ -39,21 +40,23 @@ on the **raw generation, before the strip**, and recorded per response in the
 sample's `length_info` field (visible with `--log_samples`). Two families:
 
 **Length** — `response_length_*` is always measured; the `thinking_length_*` pair
-is added only when the response contains the reasoning close token:
+is added only for **well-formed** responses (`thinking_format_correct = 1`), so a
+mis-attributed span (e.g. a close inherited from an earlier turn) is never measured:
 
 | Metric | Meaning |
 |--------|---------|
 | `response_length_words` / `_chars` / `_tokens` | Length of the full generation (reasoning + answer). `_tokens` uses the exact generated token ids, or an exact backend token count (e.g. SGLang's `completion_tokens`), when available — otherwise the `_tokens` variant is omitted for that response. |
-| `thinking_length_words` / `_chars` / `_tokens` | Length of the reasoning span (start of generation up to and including the close token). `_tokens` re-encodes the span with the tokenizer (best-effort). |
+| `thinking_length_words` / `_chars` / `_tokens` | Length of the reasoning span (start of generation up to and including the **last** close token — the same boundary the strip uses). Recorded only when `thinking_format_correct = 1`. `_tokens` is an exact token count on the `hf` int-token path, else a best-effort tokenizer re-encode of the span. |
 
 **Thinking-format** (`thinking_format_*`, 0/1 per response) — a well-formedness
-signal for reasoning models:
+signal for reasoning models, computed on the **current turn only** (the rendered
+history is never consulted, so a prior turn cannot leak into the signal):
 
 | Metric | Meaning |
 |--------|---------|
-| `thinking_format_has_open` | The reasoning open token is present in the prompt **or** generation (thinking templates usually prefill the open into the prompt). |
+| `thinking_format_has_open` | The block was opened **this turn**: the open token is emitted in the generation, or injected by the template's generation prompt (a prefill template). Emitted only when an open token is known. |
 | `thinking_format_has_close` | The reasoning close token is present in the generation (the model emitted it). |
-| `thinking_format_correct` | Open present, close present, open precedes close, and the block is not re-opened after the close. |
+| `thinking_format_correct` | **Open+close models:** open present (this turn), close present, open precedes the (last) close, block not re-opened after the (first) close. **Close-only models** (no open token): reduces to `has_close`. |
 
 ## What is logged, where, and under which flags
 
@@ -64,9 +67,12 @@ signal for reasoning models:
 | W&B (native, by the harness) | `--wandb_args` (uploads whatever was aggregated) | only with `--log_length_metrics` | always (when token resolved) |
 
 Aggregation is a per-task **mean over documents**. "Always (when token resolved)"
-means `thinking_format_*` needs no `--log_length_metrics`, but each flag is only
-produced when its token resolved: `has_open`/`correct` require the open token,
-`has_close`/`correct` the close token (see fail-loud above).
+means `thinking_format_*` needs no `--log_length_metrics`, but the flags are only
+produced when **thinking is enabled** and the relevant token resolved: `has_open`
+requires the open token; `has_close` and `correct` require the close token (`correct`
+is emitted whenever the close is known — for close-only models it equals `has_close`;
+see fail-loud above). With `enable_thinking=false` no `thinking_*` metric is emitted —
+only `response_length_*`.
 
 **Aggregated key naming.** Aggregated metrics carry the `none` filter. In
 `results.json` the key is `thinking_format_correct,none` (nested under the task,
@@ -79,31 +85,47 @@ and the task creates **one `Instance` per turn**. At aggregation, all turns of a
 document are grouped by `doc_id` and averaged into a **single per-doc value**
 (so a 5-turn doc weighs the same as a 1-turn doc, not 5×).
 
+The open is searched in the **current turn only** (the model's generation plus, for
+prefill templates, the turn's own generation-prompt prefill) — never the rendered
+history — so a prior turn's unclosed open cannot inflate `has_open`/`correct`. This
+holds for both prefill and non-prefill models, single- and multi-turn.
+
+**Limitation — no cross-turn thinking blocks.** A reasoning block that opens in one
+turn and closes in a *later* turn is never stitched together. Such turns are
+malformed per-turn (`correct = 0`: the opening turn never closes; the closing turn
+never opened this turn), so neither contributes a (mis-attributed) `thinking_length`
+— only their `response_length` counts. For prefill templates this never arises (every
+turn re-opens its own block).
+
 ## How length is handled for malformed or non-thinking responses
 
-This describes the **aggregated** numbers (`--log_length_metrics`); the raw
-per-sample `length_info` always reflects exactly what was measured. The aggregator
-pairs each `thinking_length_<unit>` with its `response_length_<unit>` on an
-identical per-response basis, so the two always have the same sample count and
-thinking length can never exceed response length:
+This describes the **aggregated** numbers (`--log_length_metrics`). Two separate
+bases — the key design point:
 
-- **No thinking at all** (non-reasoning model/run, or `enable_thinking=false`):
-  `response_length_*` is measured normally; `thinking_length_*` is **0** for every
-  response (it is still emitted, paired with response length — not omitted).
-- **Malformed — opened but never closed** (`thinking_format_has_close = 0`): there
-  is no close token to bound the reasoning span, so `thinking_length_*` counts as
-  **0** for that response (and `thinking_format_correct = 0` flags it). The full
-  reasoning text still counts toward `response_length_*`, and — because the strip
-  keys off the close token — an unclosed block is **not** stripped, so the
-  reasoning remains in the scored text for that response.
-- **Per-doc / repeats:** the per-task value is the mean over documents; within a
-  doc with multiple samples, each is averaged, so a doc that closed on some
-  samples and not others gets a fractional `thinking_length` (e.g. `mean(90, 0)`).
-- **Measurement gaps:** a response carrying a `thinking_length_<unit>` with no
-  matching `response_length_<unit>` is dropped for that unit, keeping the bases
-  aligned. Consequence: the `_tokens` family can have a **smaller sample base**
-  than `_words`/`_chars` on backends that don't expose token counts for every
-  response.
+- **`response_length_*`** is averaged over **all** responses.
+- **`thinking_length_*`** is averaged over **well-formed responses only**
+  (`thinking_format_correct = 1`). Malformed/incorrect responses simply do not carry
+  a `thinking_length`, so they are **excluded from its denominator** — the average is
+  never biased by them (no zero-fill).
+
+Cases:
+
+- **No thinking / `enable_thinking=false`:** only `response_length_*` is emitted; no
+  `thinking_format_*` and no `thinking_length_*`.
+- **Malformed — opened but never closed** (`has_close = 0`, `correct = 0`): no
+  `thinking_length` is recorded for that response; it is excluded from the
+  thinking-length average but still counts toward `response_length_*`. Because the
+  strip keys off the close token, an unclosed block is **not** stripped, so the
+  reasoning remains in the scored text.
+- **Per-doc / repeats:** one value per doc — the mean over that doc's responses
+  carrying the key. A doc with **no** well-formed response contributes no
+  `thinking_length` value at all (it leaves the thinking-length denominator too).
+- **Consequence — bases differ:** because the two metrics average over different
+  populations, the aggregate `thinking_length` is **not bounded by** the aggregate
+  `response_length` (it can even exceed it when the well-formed responses are the
+  long ones). The **per-sample** invariant `thinking ≤ response` still always holds.
+- **Measurement gaps:** the `_tokens` family can have a **smaller sample base** than
+  `_words`/`_chars` on backends that don't expose token counts for every response.
 
 ### Impact summary (direction of bias)
 
@@ -112,13 +134,9 @@ As the share of **malformed (opened-but-not-closed)** responses rises:
 | Quantity | Direction | Why |
 |----------|-----------|-----|
 | `thinking_format_has_close`, `thinking_format_correct` | **down** | flagged 0 per malformed response — this is the signal you want |
-| `thinking_length_*` (aggregate) | **deflated** | malformed responses contribute 0 to the mean |
-| `response_length_*` | **unaffected / relatively high** | still counts the full text, reasoning included |
+| `thinking_length_*` (aggregate) | **unbiased** | averaged over the well-formed responses only; malformed ones are excluded from the denominator, not counted as 0 |
+| `response_length_*` | **unaffected / relatively high** | still counts the full text of every response, reasoning included |
 | **task score** | **likely deflated** | the un-stripped reasoning stays in the scored text and pollutes answer extraction |
-
-For a **non-thinking** run all `thinking_*` metrics sit at 0 by construction
-(expected, not a problem); `response_length_*` is normal. `thinking_format_has_open`
-can instead be **inflated** under few-shot / multi-turn (see Caveats).
 
 ## Caveats
 
@@ -128,6 +146,10 @@ can instead be **inflated** under few-shot / multi-turn (see Caveats).
   though the answer is correct. Prefer a robust extractor (`flexible-extract`, or
   a CoT/zero-shot task variant). `thinking_format_*` + the length split help
   distinguish "reasoned fine, extractor too strict" from a real thinking failure.
-- **`thinking_format_has_open` / `correct` over-count** under **few-shot** (demo
-  think tags in the prompt) and **multi-turn** (a prior turn's unclosed open leaks
-  into the next turn's rendered history).
+- **`has_open` is current-turn only** (see Multi-turn above), so few-shot demo tags
+  and a prior turn's unclosed open can't inflate it. On prefill templates it is
+  ~always 1, so `correct` there tracks whether the turn *closed*.
+- **Response caching.** The metrics are measured *during generation*, so a response
+  served from the `--cache_requests` cache (which skips generation) carries no
+  `length_info` and is excluded from these aggregates. Re-run without a cache hit
+  (or without `--cache_requests`) to populate them for every doc.

--- a/docs/thinking_evals.md
+++ b/docs/thinking_evals.md
@@ -1,0 +1,133 @@
+# Thinking / reasoning evals
+
+How the harness handles reasoning ("thinking") models on generative tasks: the
+reasoning-trace strip, and the per-response **length** and **thinking-format**
+metrics it records.
+
+For the CLI flags and `--model_args` keys that control all of this, see the
+[CLI reference](./interface.md#generation-length--thinking-format-metrics). This
+page is the conceptual reference for what those options do.
+
+## Reasoning tokens and the strip
+
+Reasoning models wrap their deliberation in an **open**/**close** token pair
+(e.g. `<think>`/`</think>`, or `<|inner_prefix|>`/`<|inner_suffix|>`). Before
+answer extraction, the `hf`, `vllm`, and `sglang` backends **strip** everything
+up to and including the close token, so only the post-reasoning answer is scored.
+
+- The tokens are **auto-detected** from the model's chat template (`inner_token` /
+  `outer_token` declarations), or set explicitly via the `think_start_token` /
+  `think_end_token` `--model_args`.
+- The **close** token (`think_end_token`) is what drives the strip; on `hf` it may
+  also be an integer token id.
+- **Fail-loud:** when thinking is enabled but the close token cannot be resolved,
+  model construction raises — pass `think_end_token=` explicitly, or set
+  `enable_thinking=false`. This prevents silently scoring un-stripped reasoning.
+  (On `hf` the guard defaults to enabled, so a reasoning-declaring template with an
+  unresolvable close raises even if you never set `enable_thinking`.) A missing
+  **open** token only warns — `has_open`/`correct` are then not tracked unless you
+  pass `think_start_token=`.
+
+> If the close token is wrong/unresolved, the reasoning is **not** stripped and
+> pollutes answer extraction. The metrics below (`thinking_format_has_close`,
+> `thinking_length_*`) make that visible.
+
+## The metrics
+
+For `generate_until` (and `multi_turn_generate`) tasks, each response is measured
+on the **raw generation, before the strip**, and recorded per response in the
+sample's `length_info` field (visible with `--log_samples`). Two families:
+
+**Length** — `response_length_*` is always measured; the `thinking_length_*` pair
+is added only when the response contains the reasoning close token:
+
+| Metric | Meaning |
+|--------|---------|
+| `response_length_words` / `_chars` / `_tokens` | Length of the full generation (reasoning + answer). `_tokens` uses the exact generated token ids, or an exact backend token count (e.g. SGLang's `completion_tokens`), when available — otherwise the `_tokens` variant is omitted for that response. |
+| `thinking_length_words` / `_chars` / `_tokens` | Length of the reasoning span (start of generation up to and including the close token). `_tokens` re-encodes the span with the tokenizer (best-effort). |
+
+**Thinking-format** (`thinking_format_*`, 0/1 per response) — a well-formedness
+signal for reasoning models:
+
+| Metric | Meaning |
+|--------|---------|
+| `thinking_format_has_open` | The reasoning open token is present in the prompt **or** generation (thinking templates usually prefill the open into the prompt). |
+| `thinking_format_has_close` | The reasoning close token is present in the generation (the model emitted it). |
+| `thinking_format_correct` | Open present, close present, open precedes close, and the block is not re-opened after the close. |
+
+## What is logged, where, and under which flags
+
+| Sink | Flag | Length (`response_length_*`, `thinking_length_*`) | Format (`thinking_format_*`) |
+|------|------|---------------------------------------------------|------------------------------|
+| Per-sample, on disk (`length_info` in `samples_*.jsonl`) | `--log_samples` | yes | yes |
+| Per-task aggregate (`results.json` + printed table) | length: `--log_length_metrics`; format: none | only with the flag | always (when token resolved) |
+| W&B (native, by the harness) | `--wandb_args` (uploads whatever was aggregated) | only with `--log_length_metrics` | always (when token resolved) |
+
+Aggregation is a per-task **mean over documents**. "Always (when token resolved)"
+means `thinking_format_*` needs no `--log_length_metrics`, but each flag is only
+produced when its token resolved: `has_open`/`correct` require the open token,
+`has_close`/`correct` the close token (see fail-loud above).
+
+**Aggregated key naming.** Aggregated metrics carry the `none` filter. In
+`results.json` the key is `thinking_format_correct,none` (nested under the task,
+e.g. `results["gsm8k"]`). In **W&B** the trailing `,none` is stripped, so it
+appears as `gsm8k/thinking_format_correct`.
+
+**Multi-turn (`multi_turn_generate`).** Each turn is a separate `generate_until`
+response: the strip and the per-response length/format are measured **per turn**,
+and the task creates **one `Instance` per turn**. At aggregation, all turns of a
+document are grouped by `doc_id` and averaged into a **single per-doc value**
+(so a 5-turn doc weighs the same as a 1-turn doc, not 5×).
+
+## How length is handled for malformed or non-thinking responses
+
+This describes the **aggregated** numbers (`--log_length_metrics`); the raw
+per-sample `length_info` always reflects exactly what was measured. The aggregator
+pairs each `thinking_length_<unit>` with its `response_length_<unit>` on an
+identical per-response basis, so the two always have the same sample count and
+thinking length can never exceed response length:
+
+- **No thinking at all** (non-reasoning model/run, or `enable_thinking=false`):
+  `response_length_*` is measured normally; `thinking_length_*` is **0** for every
+  response (it is still emitted, paired with response length — not omitted).
+- **Malformed — opened but never closed** (`thinking_format_has_close = 0`): there
+  is no close token to bound the reasoning span, so `thinking_length_*` counts as
+  **0** for that response (and `thinking_format_correct = 0` flags it). The full
+  reasoning text still counts toward `response_length_*`, and — because the strip
+  keys off the close token — an unclosed block is **not** stripped, so the
+  reasoning remains in the scored text for that response.
+- **Per-doc / repeats:** the per-task value is the mean over documents; within a
+  doc with multiple samples, each is averaged, so a doc that closed on some
+  samples and not others gets a fractional `thinking_length` (e.g. `mean(90, 0)`).
+- **Measurement gaps:** a response carrying a `thinking_length_<unit>` with no
+  matching `response_length_<unit>` is dropped for that unit, keeping the bases
+  aligned. Consequence: the `_tokens` family can have a **smaller sample base**
+  than `_words`/`_chars` on backends that don't expose token counts for every
+  response.
+
+### Impact summary (direction of bias)
+
+As the share of **malformed (opened-but-not-closed)** responses rises:
+
+| Quantity | Direction | Why |
+|----------|-----------|-----|
+| `thinking_format_has_close`, `thinking_format_correct` | **down** | flagged 0 per malformed response — this is the signal you want |
+| `thinking_length_*` (aggregate) | **deflated** | malformed responses contribute 0 to the mean |
+| `response_length_*` | **unaffected / relatively high** | still counts the full text, reasoning included |
+| **task score** | **likely deflated** | the un-stripped reasoning stays in the scored text and pollutes answer extraction |
+
+For a **non-thinking** run all `thinking_*` metrics sit at 0 by construction
+(expected, not a problem); `response_length_*` is normal. `thinking_format_has_open`
+can instead be **inflated** under few-shot / multi-turn (see Caveats).
+
+## Caveats
+
+- **Answer extraction.** A reasoning model often answers in its own style after
+  the close token (a bare number, `\boxed{...}`), which a strict
+  format-specific extractor (e.g. gsm8k's `strict-match` `#### N`) will miss even
+  though the answer is correct. Prefer a robust extractor (`flexible-extract`, or
+  a CoT/zero-shot task variant). `thinking_format_*` + the length split help
+  distinguish "reasoned fine, extractor too strict" from a real thinking failure.
+- **`thinking_format_has_open` / `correct` over-count** under **few-shot** (demo
+  think tags in the prompt) and **multi-turn** (a prior turn's unclosed open leaks
+  into the next turn's rendered history).

--- a/docs/thinking_evals.md
+++ b/docs/thinking_evals.md
@@ -1,155 +1,318 @@
 # Thinking / reasoning evals
 
 How the harness handles reasoning ("thinking") models on generative tasks: the
-reasoning-trace strip, and the per-response **length** and **thinking-format**
-metrics it records.
+reasoning-trace **strip**, and the per-response **length** and **thinking-format**
+metrics it records. For the exact CLI flags and `--model_args` keys, see the
+[CLI reference](./interface.md#generation-length--thinking-format-metrics).
 
-For the CLI flags and `--model_args` keys that control all of this, see the
-[CLI reference](./interface.md#generation-length--thinking-format-metrics). This
-page is the conceptual reference for what those options do.
+**Contents:** [Quick start](#quick-start) · [How it works](#how-it-works) ·
+[When things turn on](#when-things-turn-on) · [Metric reference](#metric-reference) ·
+[Aggregation](#aggregation) · [Multi-turn](#multi-turn) ·
+[Backend differences](#backend-differences) · [Troubleshooting](#troubleshooting) ·
+[Appendix: internals](#appendix-internals)
 
-## Reasoning tokens and the strip
+## Quick start
 
-Reasoning models wrap their deliberation in an **open**/**close** token pair
-(e.g. `<think>`/`</think>`, or `<|inner_prefix|>`/`<|inner_suffix|>`). Before
-answer extraction, the `hf`, `vllm`, and `sglang` backends **strip** everything
-up to and including the close token, so only the post-reasoning answer is scored.
+**The reasoning machinery is opt-in.** By default nothing is detected, nothing is
+stripped, and no thinking metric is recorded — you must name a close token, or ask the
+harness to find one.
 
-- The tokens are **auto-detected** from the model's chat template (`inner_token` /
-  `outer_token` declarations), or set explicitly via the `think_start_token` /
-  `think_end_token` `--model_args`.
-- The **close** token (`think_end_token`) is what drives the strip; on `hf` it may
-  also be an integer token id.
-- **Fail-loud:** when thinking is enabled but the close token cannot be resolved,
-  model construction raises — pass `think_end_token=` explicitly, or set
-  `enable_thinking=false`. This prevents silently scoring un-stripped reasoning.
-  (On `hf` the guard defaults to enabled, so a reasoning-declaring template with an
-  unresolvable close raises even if you never set `enable_thinking`. `sglang` has no
-  `enable_thinking` toggle — a reasoning-declaring template is always thinking-enabled.)
-  A missing **open** token only warns — `has_open` is then not tracked and `correct`
-  falls back to `has_close` (close-only style) unless you pass `think_start_token=`.
+```bash
+# 0. Defaults: no strip, no thinking metrics. Only `response_length_*` is measured.
+lm_eval --model hf --model_args pretrained=$M --tasks gsm8k --apply_chat_template
 
-> If the close token is wrong/unresolved, the reasoning is **not** stripped and
-> pollutes answer extraction. The metrics below (`thinking_format_has_close`,
-> `thinking_length_*`) make that visible.
+# 1. Opt in: read the reasoning tokens from the chat template, strip the trace before
+#    scoring, and aggregate `thinking_format_*`.
+--model_args pretrained=$M,autodetect_think_tokens=true
 
-## The metrics
+# 2. Or name the close token yourself (no template scan; `has_open` is not tracked).
+--model_args pretrained=$M,think_end_token='</think>'
 
-For `generate_until` (and `multi_turn_generate`) tasks, each response is measured
-on the **raw generation, before the strip**, and recorded per response in the
-sample's `length_info` field (visible with `--log_samples`). Two families:
+# 3. Also aggregate the lengths, and keep the per-response values on disk.
+lm_eval --model hf --model_args pretrained=$M,autodetect_think_tokens=true \
+        --tasks gsm8k --apply_chat_template --log_length_metrics --log_samples -o out/
 
-**Length** — `response_length_*` is always measured; the `thinking_length_*` pair
-is added only for **well-formed** responses (`thinking_format_correct = 1`), so a
-mis-attributed span (e.g. a close inherited from an earlier turn) is never measured:
+# 4. Strip, but skip the thinking metrics (and their per-response cost).
+--model_args pretrained=$M,autodetect_think_tokens=true,track_thinking_metrics=false
+```
+
+You get per-response values in `length_info` (sample jsonl, with `--log_samples`) and
+per-task means in `results.json` / the printed table / W&B.
+
+## How it works
+
+Reasoning models wrap their deliberation in an **open**/**close** token pair (e.g.
+`<think>`/`</think>`, or `<|inner_prefix|>`/`<|inner_suffix|>`). Once a close token is
+known, the `hf`, `vllm` and `sglang` backends **strip** everything up to and including
+the **last** close token, so only the post-reasoning answer is scored. No close token is
+known unless you pass `think_end_token=` or opt in to `autodetect_think_tokens=true`.
+
+Each response is measured *before* the strip and recorded in the sample's `length_info`
+field — one entry per response — for `generate_until` and `multi_turn_generate` tasks.
+
+```text
+generation   <think>2 + 2 is 4.</think>The answer is 4.
+             └───── thinking span ────┘└─── answer ───┘
+             └────────────── response span ───────────┘
+
+scored       The answer is 4.
+```
+
+- `response_length_*` covers the response span (reasoning **+** answer); always recorded.
+- `thinking_length_*` covers the thinking span — the same boundary the strip uses — and is
+  recorded **only for well-formed responses**, so a mis-attributed span is never measured.
+
+> **Why this matters.** If the close token is wrong or unresolved, the reasoning is
+> **not** stripped and pollutes answer extraction. `thinking_format_has_close` and
+> `thinking_length_*` are what make that visible.
+
+## When things turn on
+
+These four switches are **independent**.
+
+| Question | Answer |
+|---|---|
+| Does the model think? | `enable_thinking` — a **chat-template argument only**. See [`enable_thinking`, precisely](#enable_thinking-precisely). |
+| Are the reasoning tokens detected? | `autodetect_think_tokens` — **opt-in, default `false`**. The only lever over template scanning. |
+| Does the strip run? | Iff a **close** token is known: passed via `think_end_token`, or auto-detected. |
+| Are thinking metrics recorded? | `track_thinking_metrics`. Default: on iff a close token is known. |
+| Is response length recorded? | **Always**, for every `generate_until` response — thinking or not. |
+
+So an unconfigured run does nothing special: no detection, no strip, no thinking metrics
+— just `response_length_*`. You opt in with `autodetect_think_tokens=true` or by naming
+`think_end_token=` yourself.
+
+`enable_thinking` appears in exactly one of those rows. It does **not** gate detection,
+the strip, or metric *tracking*. It can still move metric *values*, because it changes
+the prompt the model is given — see [`enable_thinking`, precisely](#enable_thinking-precisely).
+
+### `enable_thinking`, precisely
+
+`enable_thinking` is a **chat-template argument**: it decides whether the model reasons.
+Whether it actually reaches the template differs per backend:
+
+| Backend | Unset | Set to `true` / `false` |
+|---|---|---|
+| `vllm` | Forwarded as `true` (the parameter's default) → thinking on | Forwarded |
+| `hf` | **Not forwarded** — the template's own default decides | Forwarded |
+| `sglang` | Never forwarded (no such argument) — the template's default decides | *n/a* |
+
+In particular, `enable_thinking` neither arms nor disables the strip: only a known close
+token does that. Turning thinking on does not make the harness look for the tokens, and
+turning it off does not stop it.
+
+**One indirect effect.** Because `enable_thinking` changes the *rendered prompt*, it can
+move metric **values** — never the switches. On a **prefill** template that injects the
+open token into the generation prompt only while thinking is on, `enable_thinking=false`
+means the open is no longer prefilled, so `thinking_format_has_open` (and therefore
+`correct`) reflects that. The metric is measuring the prompt you actually used, which is
+the intended behaviour.
+
+### Resolving the reasoning tokens
+
+- Forced with `think_start_token` / `think_end_token`, or — **only if you opt in with
+  `autodetect_think_tokens=true`** — read from the chat template's `inner_token` /
+  `outer_token` declarations. On `hf` the close may also be an integer token id.
+- **Auto-detection is off by default**, so an unconfigured run scans nothing: no close,
+  hence no strip and no thinking metrics. An explicit `think_end_token` is a deliberate
+  strip request and is honoured with or without auto-detection.
+- When on, detection happens at **model construction**, reading `tokenizer.chat_template`
+  directly — it does not require `--apply_chat_template`. The strip can therefore be armed
+  on a run that never renders the template.
+- **Fail-loud:** if auto-detection is on and the template declares reasoning tokens but
+  the close cannot be resolved, construction raises. Pass `think_end_token=`, or drop
+  `autodetect_think_tokens=true`. (This escape works on all three backends, including
+  `sglang`.) With auto-detection off — the default — the guard can never fire.
+- A missing **open** token only warns: `has_open` is not tracked and `correct` falls back
+  to `has_close` (close-only style). Pass `think_start_token=` to track it.
+
+### `track_thinking_metrics`
+
+Whether a close token *exists* and whether you *want thinking metrics* are separate
+questions. This `--model_args` key (all three backends) decides the second:
+
+| Value | Behaviour |
+|---|---|
+| unset (default) | **Derive**: track iff a close token is known. |
+| `true` | Force on. |
+| `false` | Force off — drop `thinking_format_*` / `thinking_length_*` and their per-response cost. |
+
+A **close token is required either way** (it defines `has_close` and the thinking span),
+so forcing it on without one warns and stays off. A missing **open** is fine: the format
+metric degrades to close-only (`correct == has_close`) and `has_open` is not emitted. An
+open *without* a close measures nothing — it warns, and the strip stays off too.
+`response_length_*` is never affected.
+
+This flag governs the **metrics, not the strip**: `track_thinking_metrics=false` still
+strips. To disable both, simply don't name a close token — neither via `think_end_token`
+nor via `autodetect_think_tokens=true`. That is the default.
+
+## Metric reference
+
+**Length** — measured on the response, before the strip:
 
 | Metric | Meaning |
 |--------|---------|
-| `response_length_words` / `_chars` / `_tokens` | Length of the full generation (reasoning + answer). `_tokens` uses the exact generated token ids, or an exact backend token count (e.g. SGLang's `completion_tokens`), when available — otherwise the `_tokens` variant is omitted for that response. |
-| `thinking_length_words` / `_chars` / `_tokens` | Length of the reasoning span (start of generation up to and including the **last** close token — the same boundary the strip uses). Recorded only when `thinking_format_correct = 1`. `_tokens` is an exact token count on the `hf` int-token path, else a best-effort tokenizer re-encode of the span. |
+| `response_length_words` / `_chars` / `_tokens` | The whole response (reasoning + answer). |
+| `thinking_length_words` / `_chars` / `_tokens` | The reasoning span: start of the generation up to and including the **last** close token. Recorded only when `thinking_format_correct = 1`. |
 
-**Thinking-format** (`thinking_format_*`, 0/1 per response) — a well-formedness
-signal for reasoning models, computed on the **current turn only** (the rendered
-history is never consulted, so a prior turn cannot leak into the signal):
+**Thinking-format** (`thinking_format_*`, 0/1 per response) — a well-formedness signal,
+computed on the **current turn only**:
 
 | Metric | Meaning |
 |--------|---------|
-| `thinking_format_has_open` | The block was opened **this turn**: the open token is emitted in the generation, or injected by the template's generation prompt (a prefill template). Emitted only when an open token is known. |
-| `thinking_format_has_close` | The reasoning close token is present in the generation (the model emitted it). |
-| `thinking_format_correct` | **Open+close models:** open present (this turn), close present, open precedes the (last) close, block not re-opened after the (first) close. **Close-only models** (no open token): reduces to `has_close`. |
+| `thinking_format_has_open` | The block was opened *this turn*: the open token is emitted in the generation, or injected by the template's generation prompt (a prefill template). Emitted only when an open token is known. |
+| `thinking_format_has_close` | The close token is present in the generation (the model emitted it). |
+| `thinking_format_correct` | **Open+close models:** open present (this turn), close present, open precedes the (last) close, and the block is not re-opened after the (first) close. **Close-only models** (no open token known): reduces to `has_close`. |
 
-## What is logged, where, and under which flags
+### Token counts (`_tokens`)
 
-| Sink | Flag | Length (`response_length_*`, `thinking_length_*`) | Format (`thinking_format_*`) |
-|------|------|---------------------------------------------------|------------------------------|
-| Per-sample, on disk (`length_info` in `samples_*.jsonl`) | `--log_samples` | yes | yes |
-| Per-task aggregate (`results.json` + printed table) | length: `--log_length_metrics`; format: none | only with the flag | always (when token resolved) |
-| W&B (native, by the harness) | `--wandb_args` (uploads whatever was aggregated) | only with `--log_length_metrics` | always (when token resolved) |
+`_tokens` is the only family whose provenance differs per backend:
 
-Aggregation is a per-task **mean over documents**. "Always (when token resolved)"
-means `thinking_format_*` needs no `--log_length_metrics`, but the flags are only
-produced when **thinking is enabled** and the relevant token resolved: `has_open`
-requires the open token; `has_close` and `correct` require the close token (`correct`
-is emitted whenever the close is known — for close-only models it equals `has_close`;
-see fail-loud above). With `enable_thinking=false` no `thinking_*` metric is emitted —
-only `response_length_*`.
+| Backend | `response_length_tokens` | `thinking_length_tokens` |
+|---|---|---|
+| `hf`, integer close | Exact generated ids, bounded to the response; **excludes** the terminating EOS. | Exact (ids up to the close). |
+| `hf`, string close | Same as above. | Re-encode of the span. |
+| `vllm` | `len(output.outputs[0].token_ids)` — includes the stop-string tokens and the EOS, which the text does not. | Re-encode of the span. |
+| `sglang` | `meta_info.completion_tokens` — includes the terminating token; **omitted** when absent. | Re-encode of the span. |
 
-**Aggregated key naming.** Aggregated metrics carry the `none` filter. In
-`results.json` the key is `thinking_format_correct,none` (nested under the task,
-e.g. `results["gsm8k"]`). In **W&B** the trailing `,none` is stripped, so it
-appears as `gsm8k/thinking_format_correct`.
+Consequences:
 
-**Multi-turn (`multi_turn_generate`).** Each turn is a separate `generate_until`
-response: the strip and the per-response length/format are measured **per turn**,
-and the task creates **one `Instance` per turn**. At aggregation, all turns of a
-document are grouped by `doc_id` and averaged into a **single per-doc value**
-(so a 5-turn doc weighs the same as a 1-turn doc, not 5×).
+- Per-sample `thinking ≤ response` holds **exactly** for `_chars` and `_words` (the
+  thinking span is a literal prefix of the response). For `_tokens` it holds only on the
+  `hf` integer-close path; elsewhere re-encoding the span in isolation can tokenize its
+  boundary differently and land 1–2 tokens over — most likely when the answer after the
+  close is very short.
+- `_tokens` can have a **smaller sample base** than `_chars`/`_words` (`sglang`, when
+  `completion_tokens` is absent).
+- **Prefer `_chars`** for strict ratios and for comparing across backends.
 
-The open is searched in the **current turn only** (the model's generation plus, for
-prefill templates, the turn's own generation-prompt prefill) — never the rendered
-history — so a prior turn's unclosed open cannot inflate `has_open`/`correct`. This
-holds for both prefill and non-prefill models, single- and multi-turn.
+## Aggregation
 
-**Limitation — no cross-turn thinking blocks.** A reasoning block that opens in one
-turn and closes in a *later* turn is never stitched together. Such turns are
-malformed per-turn (`correct = 0`: the opening turn never closes; the closing turn
-never opened this turn), so neither contributes a (mis-attributed) `thinking_length`
-— only their `response_length` counts. For prefill templates this never arises (every
-turn re-opens its own block).
+Where the numbers land:
 
-## How length is handled for malformed or non-thinking responses
+| Sink | Flag | Length | Format |
+|------|------|--------|--------|
+| Per-sample (`length_info` in `samples_*.jsonl`) | `--log_samples` | yes | yes |
+| Per-task (`results.json` + printed table) | length: `--log_length_metrics` | only with the flag | always |
+| W&B (native) | `--wandb_args` (uploads whatever was aggregated) | only with `--log_length_metrics` | always |
 
-This describes the **aggregated** numbers (`--log_length_metrics`). Two separate
-bases — the key design point:
+"Always" still requires that the metrics are **tracked** (see
+[When things turn on](#when-things-turn-on)) and the relevant token resolved.
 
-- **`response_length_*`** is averaged over **all** responses.
-- **`thinking_length_*`** is averaged over **well-formed responses only**
-  (`thinking_format_correct = 1`). Malformed/incorrect responses simply do not carry
-  a `thinking_length`, so they are **excluded from its denominator** — the average is
-  never biased by them (no zero-fill).
+Aggregation is a per-task **mean over documents**, emitted under the `none` filter; each
+metric also gets a `_stderr,none` companion. **One value per doc**: the mean over that
+doc's responses *carrying the key* (so `repeats > 1` and multi-turn collapse to one).
+
+Two different denominators — the key design point:
+
+- **`response_length_*`** averages over **all** responses.
+- **`thinking_length_*`** averages over **well-formed responses only**
+  (`thinking_format_correct = 1`). Malformed responses simply do not carry the key, so
+  they leave its denominator rather than being counted as zero.
 
 Cases:
 
-- **No thinking / `enable_thinking=false`:** only `response_length_*` is emitted; no
-  `thinking_format_*` and no `thinking_length_*`.
-- **Malformed — opened but never closed** (`has_close = 0`, `correct = 0`): no
-  `thinking_length` is recorded for that response; it is excluded from the
-  thinking-length average but still counts toward `response_length_*`. Because the
-  strip keys off the close token, an unclosed block is **not** stripped, so the
-  reasoning remains in the scored text.
-- **Per-doc / repeats:** one value per doc — the mean over that doc's responses
-  carrying the key. A doc with **no** well-formed response contributes no
-  `thinking_length` value at all (it leaves the thinking-length denominator too).
-- **Consequence — bases differ:** because the two metrics average over different
-  populations, the aggregate `thinking_length` is **not bounded by** the aggregate
-  `response_length` (it can even exceed it when the well-formed responses are the
-  long ones). The **per-sample** invariant `thinking ≤ response` still always holds.
-- **Measurement gaps:** the `_tokens` family can have a **smaller sample base** than
-  `_words`/`_chars` on backends that don't expose token counts for every response.
+- **Not tracked** (no close token — the default, unless you pass `think_end_token=` or
+  `autodetect_think_tokens=true` — or `track_thinking_metrics=false`): only
+  `response_length_*` is emitted.
+- **Malformed — opened but never closed** (`has_close = 0`): no `thinking_length` for
+  that response; it still counts toward `response_length_*`. Because the strip keys off
+  the close, an unclosed block is **not** stripped — the reasoning stays in the scored text.
+- **A doc with no well-formed response** contributes no `thinking_length` value at all.
+- **Bases differ**, so the aggregate `thinking_length` is **not bounded by** the aggregate
+  `response_length` — it can exceed it when the well-formed responses are the long ones.
 
-### Impact summary (direction of bias)
+### Direction of bias
 
 As the share of **malformed (opened-but-not-closed)** responses rises:
 
 | Quantity | Direction | Why |
 |----------|-----------|-----|
 | `thinking_format_has_close`, `thinking_format_correct` | **down** | flagged 0 per malformed response — this is the signal you want |
-| `thinking_length_*` (aggregate) | **unbiased** | averaged over the well-formed responses only; malformed ones are excluded from the denominator, not counted as 0 |
-| `response_length_*` | **unaffected / relatively high** | still counts the full text of every response, reasoning included |
+| `thinking_length_*` (aggregate) | **unbiased** | averaged over well-formed responses only; malformed ones leave the denominator, not counted as 0 |
+| `response_length_*` | **unaffected / relatively high** | still counts every response in full, reasoning included |
 | **task score** | **likely deflated** | the un-stripped reasoning stays in the scored text and pollutes answer extraction |
 
-## Caveats
+### Key naming
 
-- **Answer extraction.** A reasoning model often answers in its own style after
-  the close token (a bare number, `\boxed{...}`), which a strict
-  format-specific extractor (e.g. gsm8k's `strict-match` `#### N`) will miss even
-  though the answer is correct. Prefer a robust extractor (`flexible-extract`, or
-  a CoT/zero-shot task variant). `thinking_format_*` + the length split help
-  distinguish "reasoned fine, extractor too strict" from a real thinking failure.
-- **`has_open` is current-turn only** (see Multi-turn above), so few-shot demo tags
-  and a prior turn's unclosed open can't inflate it. On prefill templates it is
-  ~always 1, so `correct` there tracks whether the turn *closed*.
-- **Response caching.** The metrics are measured *during generation*, so a response
-  served from the `--cache_requests` cache (which skips generation) carries no
-  `length_info` and is excluded from these aggregates. Re-run without a cache hit
-  (or without `--cache_requests`) to populate them for every doc.
+Aggregated metrics carry the `none` filter. In `results.json` the key is
+`thinking_format_correct,none`, nested under the task (`results["gsm8k"]`). In **W&B**
+the trailing `,none` is stripped: `gsm8k/thinking_format_correct`.
+
+## Multi-turn
+
+For `multi_turn_generate`, each turn is a separate `generate_until` response and the task
+creates **one `Instance` per turn**, so the strip and the per-response length/format are
+measured **per turn**. At aggregation all turns of a document are grouped by `doc_id` and
+averaged into a **single per-doc value** — a 5-turn doc weighs the same as a 1-turn doc,
+not 5×.
+
+The open is searched in the **current turn only**: the model's generation plus, for
+prefill templates, that turn's own generation-prompt prefill. The rendered history is
+never consulted, so few-shot demo tags and a prior turn's unclosed open cannot inflate
+`has_open` / `correct`. This holds for prefill and non-prefill models alike, single- and
+multi-turn. On prefill templates `has_open` is ~always 1, so `correct` there effectively
+tracks whether the turn *closed*.
+
+**Limitation — no cross-turn blocks.** A reasoning block that opens in one turn and
+closes in a *later* turn is never stitched together. Both turns read `correct = 0` (the
+opening turn never closes; the closing turn never opened this turn), so neither
+contributes a mis-attributed `thinking_length` — only their `response_length` counts.
+Prefill templates never hit this, since every turn re-opens its own block.
+
+## Backend differences
+
+All three measure the response before the strip, but they bound "the response"
+differently:
+
+| | `hf` | `vllm` | `sglang` |
+|---|---|---|---|
+| Stops each sequence independently | **no** — the whole batch | yes | yes |
+| What bounds "the response" | pad/eos tail trimmed, then truncated at this sequence's own first stop | engine text (already stop-trimmed) | engine text (already stop-trimmed) |
+
+**Why `hf` needs bounding.** Its stop criteria halt the *whole batch* only once **every**
+sequence has stopped, so a sequence that finishes early keeps its row filled — with
+pad/eos after an EOS, or with **real tokens** generated past its own stop if it matched
+only a *string* stop. Measuring that raw row would inflate lengths by up to the batch
+maximum and let a longer batch sibling flip another response's `thinking_format_*`. So
+`hf` trims the tail, truncates at the sequence's own first stop, and maps that bound back
+onto the exact generated ids; the integer close is then searched inside that bounded view.
+
+`vllm` and `sglang` stop each sequence independently, so no sibling can inflate another's
+output and there is nothing to trim.
+
+**Scoring is untouched by any of this** — the bounding affects the metrics only. See
+[Token counts](#token-counts-_tokens) for the resulting comparability caveats.
+
+## Troubleshooting
+
+| Symptom | Cause | Fix |
+|---|---|---|
+| **No `thinking_*` metrics at all, and the reasoning is not stripped** | The default: auto-detection is **off**, so no close token was resolved | Pass `autodetect_think_tokens=true`, or name the close with `think_end_token=` |
+| `ValueError` at model construction, "reasoning close … could not be auto-detected" | You enabled `autodetect_think_tokens=true`, and the chat template declares `inner_token`/`outer_token` but not as a quoted literal | Pass `think_end_token=` instead, or drop `autodetect_think_tokens=true` |
+| Reasoning is stripped even though I passed `enable_thinking=false` | `enable_thinking` never controlled the strip — a close token is known (explicit, or auto-detected because you opted in), and the strip keys off the close | Remove `autodetect_think_tokens=true` / `think_end_token=` |
+| Task score low, but the reasoning looks fine | A strict extractor (e.g. gsm8k `strict-match`, `#### N`) misses the model's post-close answer style (a bare number, `\boxed{…}`) | Use a robust extractor (`flexible-extract`) or a CoT/zero-shot task variant |
+| `thinking_format_correct` is 0 everywhere, yet `has_close` is 1 | The open token **is** known but `has_open` reads 0 — the model never emits it and the prefill probe failed silently | No override for the probe today. Either read `has_close` directly, or drop the open (name only `think_end_token=`, without `autodetect_think_tokens=true`) so the metric degrades to close-only, where `correct == has_close` |
+| `thinking_format_has_close` is 0 everywhere and the model never seems to reason | A close is known, but the chat template defaults thinking **off** (`enable_thinking` was never forwarded to it) | On `hf`/`vllm`, pass `enable_thinking=true` to actually reason (`sglang` has no such argument — the template decides); or silence the metrics with `track_thinking_metrics=false` |
+| `has_open` is never emitted | No open token is known — the format metric degraded to close-only, so `correct == has_close` | Pass `think_start_token=` |
+| No `thinking_length_*` for a task | No response was well-formed | Check `thinking_format_correct` |
+| `thinking_length_tokens` > `response_length_tokens` | Re-encode drift on the non-`hf`-integer paths | Use `_chars` |
+| Aggregate `thinking_length` > aggregate `response_length` | Different denominators, by design | See [Aggregation](#aggregation) |
+| No `length_info` at all in the samples | Responses were served from the `--use_cache` response cache, which skips generation | Re-run without a cache hit. `--cache_requests` is unaffected — it caches only request *building* |
+| No `thinking_*` metrics though the model thinks | `track_thinking_metrics=false`, or no close token is known | Pass `think_end_token=` / `track_thinking_metrics=true` |
+
+## Appendix: internals
+
+- `Instance.length_info` (`lm_eval/api/instance.py`) is a `list[dict]`, one entry per
+  response, mirroring how `resps` are appended.
+- **Producers:** `generate_until` in `lm_eval/models/{huggingface,vllm_causallms,sglang_causallms}.py`,
+  via the helpers in `lm_eval/models/utils.py` (`build_length_info`,
+  `compute_generation_length_info`, `compute_thinking_format_info`, `resolve_think_tokens`,
+  `resolve_track_thinking_metrics`, `detect_open_prefilled`). Measurement never raises —
+  a failure yields no metrics for that response rather than breaking generation.
+- **Consumer:** `promote_generation_info_metrics` (`lm_eval/evaluator_utils.py`) groups by
+  `doc_id`, caps each instance at `repeats` (dropping data-parallel padding clones), and
+  emits under the `none` filter into the usual gather → mean → consolidate → W&B path.
+- The `hf` integer-close path builds the same dict **inline**, because its boundary is a
+  token id rather than a string. Keep it in sync with `build_length_info`.

--- a/lm_eval/_cli/run.py
+++ b/lm_eval/_cli/run.py
@@ -183,6 +183,13 @@ class Run(SubCommand):
             help="Save all model outputs and documents for post-hoc analysis",
         )
         data_group.add_argument(
+            "--log_length_metrics",
+            action="store_true",
+            default=argparse.SUPPRESS,
+            help="Aggregate per-response response/thinking length into per-task "
+            "metrics in results and W&B (thinking-format flags are always logged).",
+        )
+        data_group.add_argument(
             "--samples",
             "-E",
             default=None,
@@ -410,6 +417,7 @@ class Run(SubCommand):
             torch_random_seed=cfg.seed[2] if cfg.seed else None,
             fewshot_random_seed=cfg.seed[3] if cfg.seed else None,
             confirm_run_unsafe_code=cfg.confirm_run_unsafe_code,
+            log_length_metrics=cfg.log_length_metrics,
             metadata=cfg.metadata,
         )
 

--- a/lm_eval/api/instance.py
+++ b/lm_eval/api/instance.py
@@ -22,12 +22,9 @@ class Instance:
     )
     resps: list = field(default_factory=list)
     filtered_resps: dict = field(default_factory=dict)
-    # Per-response generation info, populated by generation models on the raw text
-    # before any thinking-strip. One dict per response, mirroring `resps`; empty
-    # otherwise. Carries response/thinking length (`*_length_words/chars/tokens`) and
-    # thinking-format flags (`thinking_format_has_open/has_close/correct`, 0/1). These
-    # are aggregated to per-task metrics by
-    # `evaluator_utils.promote_generation_info_metrics`.
+    # Per-response generation info measured on the raw text before any thinking-strip;
+    # one dict per response (mirroring `resps`), empty otherwise. Holds length +
+    # thinking-format keys, aggregated by `evaluator_utils.promote_generation_info_metrics`.
     length_info: list = field(default_factory=list)
 
     # initialized after init

--- a/lm_eval/api/instance.py
+++ b/lm_eval/api/instance.py
@@ -22,9 +22,10 @@ class Instance:
     )
     resps: list = field(default_factory=list)
     filtered_resps: dict = field(default_factory=dict)
-    # Per-response generation info measured on the raw text before any thinking-strip;
-    # one dict per response (mirroring `resps`), empty otherwise. Holds length +
-    # thinking-format keys, aggregated by `evaluator_utils.promote_generation_info_metrics`.
+    # Per-response generation info measured before any thinking-strip, on the backend's
+    # view of the response (hf bounds it to exclude batched over-generation); one dict per
+    # response (mirroring `resps`), empty otherwise. Holds length + thinking-format keys,
+    # aggregated by `evaluator_utils.promote_generation_info_metrics`.
     length_info: list = field(default_factory=list)
 
     # initialized after init

--- a/lm_eval/api/instance.py
+++ b/lm_eval/api/instance.py
@@ -22,9 +22,12 @@ class Instance:
     )
     resps: list = field(default_factory=list)
     filtered_resps: dict = field(default_factory=dict)
-    # Per-response generation length (response/thinking length in words/chars/tokens),
-    # populated by generation models that measure it (e.g. vLLM) on the raw text before
-    # any thinking-strip. One entry per response, mirroring `resps`; empty otherwise.
+    # Per-response generation info, populated by generation models on the raw text
+    # before any thinking-strip. One dict per response, mirroring `resps`; empty
+    # otherwise. Carries response/thinking length (`*_length_words/chars/tokens`) and
+    # thinking-format flags (`thinking_format_has_open/has_close/correct`, 0/1). These
+    # are aggregated to per-task metrics by
+    # `evaluator_utils.promote_generation_info_metrics`.
     length_info: list = field(default_factory=list)
 
     # initialized after init

--- a/lm_eval/api/instance.py
+++ b/lm_eval/api/instance.py
@@ -22,6 +22,10 @@ class Instance:
     )
     resps: list = field(default_factory=list)
     filtered_resps: dict = field(default_factory=dict)
+    # Per-response generation length (response/thinking length in words/chars/tokens),
+    # populated by generation models that measure it (e.g. vLLM) on the raw text before
+    # any thinking-strip. One entry per response, mirroring `resps`; empty otherwise.
+    length_info: list = field(default_factory=list)
 
     # initialized after init
     task_name: str | None = None

--- a/lm_eval/config/evaluate_config.py
+++ b/lm_eval/config/evaluate_config.py
@@ -112,6 +112,13 @@ class EvaluatorConfig:
     log_samples: bool = field(
         default=False, metadata={"help": "Save model outputs and inputs"}
     )
+    log_length_metrics: bool = field(
+        default=False,
+        metadata={
+            "help": "Aggregate per-response response/thinking length into per-task "
+            "metrics in results and W&B (thinking-format flags are always logged)."
+        },
+    )
     output_path: str | None = field(
         default=None, metadata={"help": "Dir path where result metrics will be saved"}
     )

--- a/lm_eval/evaluator.py
+++ b/lm_eval/evaluator.py
@@ -716,6 +716,10 @@ def evaluate(
                         "filtered_resps": [
                             req.filtered_resps[filter_key] for req in requests
                         ],
+                        # Per-response generation length measured before any
+                        # thinking-strip (populated by generation models that support
+                        # it, e.g. vLLM; empty list otherwise).
+                        "length_info": [req.length_info for req in requests],
                         "filter": filter_key,
                         "metrics": list(metrics.keys()),
                         "doc_hash": hash_string(

--- a/lm_eval/evaluator.py
+++ b/lm_eval/evaluator.py
@@ -23,6 +23,7 @@ from lm_eval.evaluator_utils import (
     get_task_list,
     prepare_print_tasks,
     print_writeout,
+    promote_generation_info_metrics,
     run_task_tests,
 )
 from lm_eval.loggers.utils import add_env_info, add_tokenizer_info, get_git_commit_hash
@@ -115,6 +116,7 @@ def simple_evaluate(
     torch_random_seed: int = DEFAULT_OTHER_SEED,
     fewshot_random_seed: int = DEFAULT_OTHER_SEED,
     confirm_run_unsafe_code: bool = False,
+    log_length_metrics: bool = False,
     metadata: dict | None = None,
 ):
     """Instantiate and evaluate a model on a list of tasks.
@@ -183,6 +185,10 @@ def simple_evaluate(
             If set to None, the seed of generator will be set to None.
         confirm_run_unsafe_code (bool): Whether to confirm running tasks marked
             as unsafe.
+        log_length_metrics (bool): If True, aggregate per-response response/thinking
+            length (from each Instance's length_info) into per-task metrics in the
+            results and W&B, in addition to the always-on thinking-format flags.
+            Off by default (length stays per-sample in the logged samples).
         metadata (dict | None): Additional metadata to be added to the task
             manager. Will get passed to the download function of the task.
 
@@ -424,6 +430,7 @@ def simple_evaluate(
         fewshot_as_multiturn=fewshot_as_multiturn,
         verbosity=verbosity,
         confirm_run_unsafe_code=confirm_run_unsafe_code,
+        log_length_metrics=log_length_metrics,
     )
     if verbosity is not None:
         setup_logging(verbosity=verbosity)
@@ -487,6 +494,7 @@ def evaluate(
     fewshot_as_multiturn: bool = False,
     verbosity: str = "INFO",
     confirm_run_unsafe_code: bool = False,
+    log_length_metrics: bool = False,
 ):
     """Instantiate and evaluate a model on a list of tasks.
 
@@ -737,6 +745,15 @@ def evaluate(
                     task_output.logged_samples.append(example)
                 for metric, value in metrics.items():
                     task_output.sample_metrics[(metric, filter_key)].append(value)
+
+    # Promote per-response generation-info (thinking-format flags always; response/
+    # thinking length when log_length_metrics is set) from each Instance's
+    # length_info into sample_metrics, so they flow through the SAME gather -> mean
+    # -> consolidate -> W&B path as ordinary metrics and surface as per-task numbers
+    # in results.json / make_table / W&B — no external aggregation needed. Runs per
+    # rank before the gather below; independent of log_samples.
+    for task_output in eval_tasks:
+        promote_generation_info_metrics(task_output, include_length=log_length_metrics)
 
     if WORLD_SIZE > 1:
         import torch

--- a/lm_eval/evaluator.py
+++ b/lm_eval/evaluator.py
@@ -724,9 +724,7 @@ def evaluate(
                         "filtered_resps": [
                             req.filtered_resps[filter_key] for req in requests
                         ],
-                        # Per-response generation length measured before any
-                        # thinking-strip (populated by generation models that support
-                        # it, e.g. vLLM; empty list otherwise).
+                        # Per-response generation info (see Instance.length_info).
                         "length_info": [req.length_info for req in requests],
                         "filter": filter_key,
                         "metrics": list(metrics.keys()),
@@ -746,12 +744,8 @@ def evaluate(
                 for metric, value in metrics.items():
                     task_output.sample_metrics[(metric, filter_key)].append(value)
 
-    # Promote per-response generation-info (thinking-format flags always; response/
-    # thinking length when log_length_metrics is set) from each Instance's
-    # length_info into sample_metrics, so they flow through the SAME gather -> mean
-    # -> consolidate -> W&B path as ordinary metrics and surface as per-task numbers
-    # in results.json / make_table / W&B — no external aggregation needed. Runs per
-    # rank before the gather below; independent of log_samples.
+    # Promote per-response generation-info into sample_metrics (per rank, before the
+    # gather below; independent of log_samples). See promote_generation_info_metrics.
     for task_output in eval_tasks:
         promote_generation_info_metrics(task_output, include_length=log_length_metrics)
 

--- a/lm_eval/evaluator.py
+++ b/lm_eval/evaluator.py
@@ -529,6 +529,9 @@ def evaluate(
         verbosity (str): Verbosity level for logging. (no-op, deprecated)
         confirm_run_unsafe_code (bool): Whether to confirm running tasks marked
             as unsafe.
+        log_length_metrics (bool): If True, also aggregate per-response response/thinking
+            length (from each Instance's length_info) into per-task metrics, alongside
+            the always-on thinking-format flags. Off by default.
 
     Returns:
         dict | None: Dictionary of results, or None if not on rank 0.

--- a/lm_eval/evaluator_utils.py
+++ b/lm_eval/evaluator_utils.py
@@ -145,13 +145,7 @@ class TaskOutput:
         )
 
 
-# Prefixes of the per-response keys (produced in each Instance.length_info by the
-# generation backends, see lm_eval/models/utils.py) that this module promotes to
-# per-task metrics; the single source of truth for the consumer-side filter.
-# `thinking_format_*` and `response_length_*` are promoted directly;
-# `thinking_length_*` is NOT promoted on its own — it is paired per-unit with
-# `response_length_*` (see promote_generation_info_metrics), so it never goes
-# through the generic filter.
+# Prefixes of the per-response Instance.length_info keys promoted by `_is_promoted`.
 THINKING_FORMAT_PREFIX = "thinking_format_"
 RESPONSE_LENGTH_PREFIX = "response_length_"
 THINKING_LENGTH_PREFIX = "thinking_length_"
@@ -162,31 +156,26 @@ def promote_generation_info_metrics(
 ) -> None:
     """Promote per-response generation-info into per-task metrics in ``sample_metrics``.
 
-    The generation backends store per-response dicts in each ``Instance.length_info``:
-    always the ``thinking_format_*`` 0/1 flags, and (with ``include_length``) the
-    ``response_length_*`` / ``thinking_length_*`` measurements.
+    Backends store per-response dicts in each ``Instance.length_info``: the
+    ``thinking_format_*`` 0/1 flags (when thinking is tracked), and (with
+    ``include_length``) the ``response_length_*`` measurements plus, **only for
+    well-formed responses** (``thinking_format_correct == 1``, gated upstream at the
+    backend), the ``thinking_length_*`` measurements.
 
-    ``thinking_format_*`` and ``response_length_*`` are promoted directly.
-    ``thinking_length_<unit>`` is instead **paired per-unit with**
-    ``response_length_<unit>``: recorded (its value, or ``0.0`` when this response did
-    not close a thinking block) for EXACTLY the responses that carry
-    ``response_length_<unit>``. So the two share an identical per-response basis and
-    count — thinking length never exceeds response length, every rank emitting
-    response length also emits thinking length (consistent gather key set), and a
-    length-less dict or an orphan thinking unit (no matching response unit) adds
-    neither.
+    Each promoted key is aggregated independently: one value per doc — the mean over
+    that doc's responses **carrying the key**. So ``response_length_*`` averages over
+    all responses, ``thinking_format_*`` (rates) over all responses, and
+    ``thinking_length_*`` over the well-formed responses only — its denominator never
+    includes malformed/incorrect responses (a doc with no well-formed response emits no
+    ``thinking_length_*`` value). Consequence: the aggregate ``thinking_length`` is the
+    mean among well-formed responses and is NOT bounded by the aggregate
+    ``response_length`` (per-sample ``thinking <= response`` still holds).
 
-    For each DOC we emit ONE value per metric — the mean over that doc's responses —
-    so the appended count equals the number of docs, matching ordinary metrics
-    (a per-response append would inflate it by ``repeats`` and mis-weight group
-    means). Instances are grouped by ``doc_id`` because ``multi_turn_generate`` uses
-    one Instance per turn; DP padding clones beyond ``repeats`` are ignored. Routed
-    under the ``none`` filter, the values flow through the existing gather ->
-    ``calculate_aggregate_metric`` (unknown metric -> mean) -> ``consolidate_results``
-    -> W&B path, surfacing as per-task numbers with no external aggregation.
-
-    Appends on each call (not idempotent); intended to run exactly once per rank
-    before the multi-rank gather.
+    Instances are grouped by ``doc_id`` (``multi_turn_generate`` uses one Instance per
+    turn); DP padding clones beyond ``repeats`` are ignored. Routed under the ``none``
+    filter through the existing gather -> mean -> consolidate -> W&B path; the gather
+    unions keys across ranks, so a rank lacking a key (e.g. no well-formed response) is
+    safe. Appends on each call (not idempotent); run once per rank before the gather.
     """
     task = task_output.task
     if task is None:
@@ -197,11 +186,11 @@ def promote_generation_info_metrics(
         return isinstance(v, (int, float)) and not isinstance(v, bool)
 
     def _is_promoted(key: str) -> bool:
-        # thinking_length_* is excluded here on purpose — it is paired with
-        # response_length_* below, not promoted through the generic filter.
         if key.startswith(THINKING_FORMAT_PREFIX):
             return True
-        return include_length and key.startswith(RESPONSE_LENGTH_PREFIX)
+        return include_length and key.startswith(
+            (RESPONSE_LENGTH_PREFIX, THINKING_LENGTH_PREFIX)
+        )
 
     def _doc_infos(inst) -> list:
         """Per-response dicts for one instance, capped at the intended sample
@@ -224,20 +213,6 @@ def promote_generation_info_metrics(
                 for key, value in info.items():
                     if _is_promoted(key) and _numeric(value):
                         per_key[key].append(float(value))
-                # Emit thinking_length_<unit> paired with response_length_<unit> (its
-                # value, else 0.0), so the two stay on an identical per-response basis
-                # (see docstring; rationale/edge cases in docs/interface.md).
-                if include_length:
-                    for rkey, rval in info.items():
-                        if not rkey.startswith(RESPONSE_LENGTH_PREFIX):
-                            continue
-                        if not _numeric(rval):
-                            continue
-                        unit = rkey[len(RESPONSE_LENGTH_PREFIX) :]
-                        tval = info.get(THINKING_LENGTH_PREFIX + unit, 0.0)
-                        per_key[THINKING_LENGTH_PREFIX + unit].append(
-                            float(tval) if _numeric(tval) else 0.0
-                        )
         for key, values in per_key.items():
             task_output.sample_metrics[(key, "none")].append(mean(values))
 

--- a/lm_eval/evaluator_utils.py
+++ b/lm_eval/evaluator_utils.py
@@ -157,25 +157,26 @@ def promote_generation_info_metrics(
     """Promote per-response generation-info into per-task metrics in ``sample_metrics``.
 
     Backends store per-response dicts in each ``Instance.length_info``: the
-    ``thinking_format_*`` 0/1 flags (when thinking is tracked), and (with
-    ``include_length``) the ``response_length_*`` measurements plus, **only for
-    well-formed responses** (``thinking_format_correct == 1``, gated upstream at the
-    backend), the ``thinking_length_*`` measurements.
+    ``thinking_format_*`` 0/1 flags (when thinking is tracked) and, with
+    ``include_length``, the ``response_length_*`` measurements plus ``thinking_length_*``
+    — the latter only for well-formed responses (``thinking_format_correct == 1``, gated
+    at the backend).
 
-    Each promoted key is aggregated independently: one value per doc — the mean over
-    that doc's responses **carrying the key**. So ``response_length_*`` averages over
-    all responses, ``thinking_format_*`` (rates) over all responses, and
-    ``thinking_length_*`` over the well-formed responses only — its denominator never
-    includes malformed/incorrect responses (a doc with no well-formed response emits no
-    ``thinking_length_*`` value). Consequence: the aggregate ``thinking_length`` is the
-    mean among well-formed responses and is NOT bounded by the aggregate
-    ``response_length`` (per-sample ``thinking <= response`` still holds).
+    Each key aggregates independently to one value per doc: the mean over that doc's
+    responses **carrying the key**. So ``response_length_*`` and the ``thinking_format_*``
+    rates average over all responses, while ``thinking_length_*`` averages over the
+    well-formed ones only — malformed responses leave its denominator rather than
+    zero-filling it (a doc with none emits no value). Consequence: the aggregate
+    ``thinking_length`` is NOT bounded by the aggregate ``response_length``. Per-sample,
+    ``thinking <= response`` holds exactly for ``_chars``/``_words``; for ``_tokens`` it
+    can drift by a token or two wherever the span is re-encoded rather than counted
+    (everything but the ``hf`` int-token path).
 
-    Instances are grouped by ``doc_id`` (``multi_turn_generate`` uses one Instance per
-    turn); DP padding clones beyond ``repeats`` are ignored. Routed under the ``none``
-    filter through the existing gather -> mean -> consolidate -> W&B path; the gather
-    unions keys across ranks, so a rank lacking a key (e.g. no well-formed response) is
-    safe. Appends on each call (not idempotent); run once per rank before the gather.
+    Instances are grouped by ``doc_id`` (``multi_turn_generate`` emits one per turn); DP
+    padding clones beyond ``repeats`` are ignored. Emitted under the ``none`` filter into
+    the existing gather -> mean -> consolidate -> W&B path, whose gather unions keys
+    across ranks, so a rank missing a key is safe. Appends on each call (not idempotent):
+    run once per rank, before the gather.
     """
     task = task_output.task
     if task is None:
@@ -593,10 +594,20 @@ def consolidate_group_results(
                                 stderrs, sizes
                             )
 
-                results[group_or_task]["samples"] = sum(sizes)
-                group_metadata = group_config.get("metadata", None)
-                if group_metadata is not None:
-                    versions[group_or_task] = group_metadata.get("version", None)
+            # The group's sample count is a property of the GROUP, not of whichever metric
+            # `metric_list` happened to iterate last. `sizes` above is filtered to the
+            # subtasks carrying that one metric, so assigning from it inside the loop made
+            # `samples` depend on set-iteration order and undercount whenever the last
+            # metric was sparse (present on only some subtasks) — e.g. a promoted
+            # `thinking_format_*` key. `samples` is reported in results.json and reused as
+            # the pooling weight by any PARENT group, so the error propagated upward.
+            results[group_or_task]["samples"] = sum(
+                results[task].get("samples", 0) for task in task_list
+            )
+
+            group_metadata = group_config.get("metadata", None)
+            if group_metadata is not None:
+                versions[group_or_task] = group_metadata.get("version", None)
 
             # Clean up duplicate score rows for subtasks that also report other metrics.
             for task in task_list:

--- a/lm_eval/evaluator_utils.py
+++ b/lm_eval/evaluator_utils.py
@@ -14,6 +14,7 @@ from lm_eval.api.metrics import (
 from lm_eval.api.task import Task
 from lm_eval.utils import positional_deprecated
 
+
 eval_logger = logging.getLogger(__name__)
 
 
@@ -110,7 +111,12 @@ class TaskOutput:
                 agg_fn = mean
             metric_key = f"{metric},{filter_key}"
             self.agg_metrics[metric_key] = agg_fn(items)
-            self.sample_len = len(items)  # TODO: same sample size for each metric?
+            # Report the largest per-metric sample count as the task's sample size.
+            # Most metrics share the doc count, but promoted per-response info
+            # metrics (e.g. thinking_length only on docs that reasoned) can be
+            # sparser; a plain last-wins assignment would undercount `samples` and
+            # mis-weight group pooling.
+            self.sample_len = max(self.sample_len or 0, len(items))
             if isinstance(bootstrap_iters, int):
                 stderr_fn = stderr_for_metric(
                     metric=agg_fn,
@@ -137,6 +143,69 @@ class TaskOutput:
             f"task_alias={self.task_alias}, "
             f"group_alias={self.group_alias})"
         )
+
+
+# Prefixes of per-response keys (produced in each Instance.length_info by the
+# generation backends, see lm_eval/models/utils.py) that this module promotes to
+# per-task metrics. Kept here as the single source of truth for the consumer-side
+# filter; the producers must emit keys under these prefixes.
+THINKING_FORMAT_PREFIX = "thinking_format_"
+LENGTH_PREFIXES = ("response_length_", "thinking_length_")
+
+
+def promote_generation_info_metrics(
+    task_output: "TaskOutput", include_length: bool = False
+) -> None:
+    """Promote per-response generation-info into per-task metrics in ``sample_metrics``.
+
+    The generation backends store per-response dicts in each ``Instance.length_info``:
+    always the ``thinking_format_*`` 0/1 flags, and (with ``include_length``) the
+    ``response_length_*`` / ``thinking_length_*`` measurements.
+
+    For each DOC we emit ONE value per metric — the mean over that doc's responses —
+    so the appended count equals the number of docs, matching ordinary metrics
+    (a per-response append would inflate it by ``repeats`` and mis-weight group
+    means). Instances are grouped by ``doc_id`` because ``multi_turn_generate`` uses
+    one Instance per turn; DP padding clones beyond ``repeats`` are ignored. Routed
+    under the ``none`` filter, the values flow through the existing gather ->
+    ``calculate_aggregate_metric`` (unknown metric -> mean) -> ``consolidate_results``
+    -> W&B path, surfacing as per-task numbers with no external aggregation.
+
+    Appends on each call (not idempotent); intended to run exactly once per rank
+    before the multi-rank gather.
+    """
+    task = task_output.task
+    if task is None:
+        return
+
+    def _is_promoted(key: str) -> bool:
+        if key.startswith(THINKING_FORMAT_PREFIX):
+            return True
+        return include_length and key.startswith(LENGTH_PREFIXES)
+
+    by_doc: dict = collections.defaultdict(list)
+    for inst in getattr(task, "instances", []):
+        by_doc[inst.doc_id].append(inst)
+    for insts in by_doc.values():
+        per_key: dict = collections.defaultdict(list)
+        for inst in insts:
+            infos = getattr(inst, "length_info", None) or []
+            # cap at the intended sample count; DP padding can append extra clones.
+            n = getattr(inst, "repeats", None)
+            if isinstance(n, int) and n > 0:
+                infos = infos[:n]
+            for info in infos:
+                if not isinstance(info, dict):
+                    continue
+                for key, value in info.items():
+                    if (
+                        _is_promoted(key)
+                        and isinstance(value, (int, float))
+                        and not isinstance(value, bool)
+                    ):
+                        per_key[key].append(float(value))
+        for key, values in per_key.items():
+            task_output.sample_metrics[(key, "none")].append(mean(values))
 
 
 def get_task_list(task_dict: dict) -> list[TaskOutput]:

--- a/lm_eval/evaluator_utils.py
+++ b/lm_eval/evaluator_utils.py
@@ -145,12 +145,16 @@ class TaskOutput:
         )
 
 
-# Prefixes of per-response keys (produced in each Instance.length_info by the
+# Prefixes of the per-response keys (produced in each Instance.length_info by the
 # generation backends, see lm_eval/models/utils.py) that this module promotes to
-# per-task metrics. Kept here as the single source of truth for the consumer-side
-# filter; the producers must emit keys under these prefixes.
+# per-task metrics; the single source of truth for the consumer-side filter.
+# `thinking_format_*` and `response_length_*` are promoted directly;
+# `thinking_length_*` is NOT promoted on its own — it is paired per-unit with
+# `response_length_*` (see promote_generation_info_metrics), so it never goes
+# through the generic filter.
 THINKING_FORMAT_PREFIX = "thinking_format_"
-LENGTH_PREFIXES = ("response_length_", "thinking_length_")
+RESPONSE_LENGTH_PREFIX = "response_length_"
+THINKING_LENGTH_PREFIX = "thinking_length_"
 
 
 def promote_generation_info_metrics(
@@ -161,6 +165,16 @@ def promote_generation_info_metrics(
     The generation backends store per-response dicts in each ``Instance.length_info``:
     always the ``thinking_format_*`` 0/1 flags, and (with ``include_length``) the
     ``response_length_*`` / ``thinking_length_*`` measurements.
+
+    ``thinking_format_*`` and ``response_length_*`` are promoted directly.
+    ``thinking_length_<unit>`` is instead **paired per-unit with**
+    ``response_length_<unit>``: recorded (its value, or ``0.0`` when this response did
+    not close a thinking block) for EXACTLY the responses that carry
+    ``response_length_<unit>``. So the two share an identical per-response basis and
+    count — thinking length never exceeds response length, every rank emitting
+    response length also emits thinking length (consistent gather key set), and a
+    length-less dict or an orphan thinking unit (no matching response unit) adds
+    neither.
 
     For each DOC we emit ONE value per metric — the mean over that doc's responses —
     so the appended count equals the number of docs, matching ordinary metrics
@@ -178,32 +192,52 @@ def promote_generation_info_metrics(
     if task is None:
         return
 
+    def _numeric(v) -> bool:
+        # bool is an int subclass; flags/lengths are plain ints, so exclude bool.
+        return isinstance(v, (int, float)) and not isinstance(v, bool)
+
     def _is_promoted(key: str) -> bool:
+        # thinking_length_* is excluded here on purpose — it is paired with
+        # response_length_* below, not promoted through the generic filter.
         if key.startswith(THINKING_FORMAT_PREFIX):
             return True
-        return include_length and key.startswith(LENGTH_PREFIXES)
+        return include_length and key.startswith(RESPONSE_LENGTH_PREFIX)
+
+    def _doc_infos(inst) -> list:
+        """Per-response dicts for one instance, capped at the intended sample
+        count (DP padding can append extra clones beyond ``repeats``).
+        """
+        infos = getattr(inst, "length_info", None) or []
+        n = getattr(inst, "repeats", None)
+        if isinstance(n, int) and n > 0:
+            infos = infos[:n]
+        return [info for info in infos if isinstance(info, dict)]
 
     by_doc: dict = collections.defaultdict(list)
     for inst in getattr(task, "instances", []):
         by_doc[inst.doc_id].append(inst)
+
     for insts in by_doc.values():
         per_key: dict = collections.defaultdict(list)
         for inst in insts:
-            infos = getattr(inst, "length_info", None) or []
-            # cap at the intended sample count; DP padding can append extra clones.
-            n = getattr(inst, "repeats", None)
-            if isinstance(n, int) and n > 0:
-                infos = infos[:n]
-            for info in infos:
-                if not isinstance(info, dict):
-                    continue
+            for info in _doc_infos(inst):
                 for key, value in info.items():
-                    if (
-                        _is_promoted(key)
-                        and isinstance(value, (int, float))
-                        and not isinstance(value, bool)
-                    ):
+                    if _is_promoted(key) and _numeric(value):
                         per_key[key].append(float(value))
+                # Emit thinking_length_<unit> paired with response_length_<unit> (its
+                # value, else 0.0), so the two stay on an identical per-response basis
+                # (see docstring; rationale/edge cases in docs/interface.md).
+                if include_length:
+                    for rkey, rval in info.items():
+                        if not rkey.startswith(RESPONSE_LENGTH_PREFIX):
+                            continue
+                        if not _numeric(rval):
+                            continue
+                        unit = rkey[len(RESPONSE_LENGTH_PREFIX) :]
+                        tval = info.get(THINKING_LENGTH_PREFIX + unit, 0.0)
+                        per_key[THINKING_LENGTH_PREFIX + unit].append(
+                            float(tval) if _numeric(tval) else 0.0
+                        )
         for key, values in per_key.items():
             task_output.sample_metrics[(key, "none")].append(mean(values))
 

--- a/lm_eval/loggers/wandb_logger.py
+++ b/lm_eval/loggers/wandb_logger.py
@@ -236,6 +236,13 @@ class WandbLogger:
         metrics = {}
         for metric in metrics_list:
             metric = metric.get("metric")
+            # A metric declared as a `!function` (e.g. humaneval's pass_at_k) is a
+            # callable whose actual per-sample keys differ (pass@1/pass@10), and some
+            # declared metrics aren't logged per sample. Only build columns for string
+            # metric names present on every sample, else `x[metric]` raises KeyError
+            # and aborts the whole samples-table upload.
+            if not isinstance(metric, str) or not all(metric in x for x in data):
+                continue
             if metric in ["word_perplexity", "byte_perplexity", "bits_per_byte"]:
                 metrics[f"{metric}_loglikelihood"] = [x[metric][0] for x in data]
                 if metric in ["byte_perplexity", "bits_per_byte"]:

--- a/lm_eval/models/huggingface.py
+++ b/lm_eval/models/huggingface.py
@@ -32,10 +32,13 @@ from lm_eval.api.registry import register_model
 from lm_eval.models.utils import (
     Collator,
     _add_special_kwargs,
+    attach_length_info,
+    build_length_info,
     check_system_boilerplate,
     compute_generation_length_info,
     compute_thinking_format_info,
     configure_pad_token,
+    detect_open_prefilled,
     get_template_special_tokens,
     handle_stop_sequences,
     has_bos_prefix,
@@ -280,13 +283,10 @@ class HFLM(TemplateLM):
         if enable_thinking is not None:
             self.chat_template_args["enable_thinking"] = enable_thinking
 
-        # Resolve the reasoning open/close tokens from the model's chat template when
-        # the caller didn't set them. self.think_end_token may be an int (token id)
-        # used by the token-level strip below; self.think_end_token_str is always the
-        # *string* close used by the thinking-format metric — including when an int
-        # token id was supplied, in which case we decode it so the format metric and
-        # the strip reference the same boundary (and so a valid int close never
-        # triggers the fail-loud guard meant for an unresolvable close).
+        # think_end_token may be an int (token id) for the strip; think_end_token_str
+        # is the string close used by the format metric — decoded from the int when
+        # needed so the strip and metric share one boundary (and a valid int close
+        # never trips the fail-loud guard).
         _chat_template = getattr(self.tokenizer, "chat_template", None)
         _forced_close_str = None
         if isinstance(self.think_end_token, str):
@@ -297,9 +297,8 @@ class HFLM(TemplateLM):
                     self.tok_decode([self.think_end_token], skip_special_tokens=False)
                     or None
                 )
-        # Default to True (like vLLM/SGLang) so the fail-loud close-token guard is
-        # consistent across backends: it still only fires for reasoning-declaring
-        # templates, and a user can disable it with enable_thinking=False.
+        # Default enable_thinking True (as in vLLM/SGLang); the fail-loud guard still
+        # only fires for reasoning-declaring templates.
         self.think_start_token, self.think_end_token_str = resolve_think_tokens(
             _chat_template,
             self.chat_template_args.get("enable_thinking", True),
@@ -308,6 +307,18 @@ class HFLM(TemplateLM):
         )
         if self.think_end_token is None:
             self.think_end_token = self.think_end_token_str
+
+        # Whether the template prefills the reasoning open into the generation prompt
+        # (vs the model emitting it); feeds the per-turn has_open check.
+        self.think_open_prefilled = detect_open_prefilled(
+            self.apply_chat_template, self.think_start_token
+        )
+        # Track thinking metrics only when thinking is on and a close token is known.
+        # Gate on the *string* close (think_end_token may be an int token id here).
+        self.track_thinking_metrics = bool(
+            self.chat_template_args.get("enable_thinking", True)
+            and self.think_end_token_str
+        )
 
         # System-prompt authority probe — OFF by default. Run it only when the
         # caller opts in via `check_system_prompt_authority` (and hasn't waived it with
@@ -1556,24 +1567,47 @@ class HFLM(TemplateLM):
                 if self.backend == "causal":
                     cont_toks = cont_toks[context_enc.shape[1] :]
 
-                # Locate the thinking boundary once (int think_end_token = token id);
-                # reused for both length logging and the strip below.
+                # Thinking boundary indices (int close = token id); reused for the
+                # length info and the strip below.
                 think_token_indices = (
                     [i for i, t in enumerate(cont_toks) if t == self.think_end_token]
                     if isinstance(self.think_end_token, int)
                     else None
                 )
 
-                # Length of the RAW generation (full cont_toks, before the thinking
-                # span is stripped below), for per-sample logging. think_end_token may
-                # be a token id (int) or a string; both mark the same boundary.
+                # Length of the RAW generation, before the strip below.
                 raw_gen_text = self.tok_decode(cont_toks, skip_special_tokens=False)
                 if isinstance(self.think_end_token, int):
-                    len_info = compute_generation_length_info(
-                        raw_gen_text,
-                        token_ids=cont_toks,
+                    # Int-token path: builds the same length+format dict as
+                    # build_length_info but with a token-id thinking span instead of a
+                    # string one — keep the two in sync on any length/format change.
+                    # Format uses the string close, but has_close / correct MUST reflect
+                    # the int-token boundary the strip actually uses (below), so the
+                    # metric never claims well-formed while the strip is skipped
+                    # (string/int tokenizations can disagree).
+                    fmt = (
+                        compute_thinking_format_info(
+                            raw_gen_text,
+                            think_start_token=self.think_start_token,
+                            think_end_token=self.think_end_token_str,
+                            open_prefilled=self.think_open_prefilled,
+                        )
+                        if self.track_thinking_metrics
+                        else {}
                     )
-                    if think_token_indices:
+                    if fmt:
+                        int_has_close = bool(think_token_indices)
+                        fmt["thinking_format_has_close"] = int(int_has_close)
+                        if "thinking_format_correct" in fmt:
+                            fmt["thinking_format_correct"] = int(
+                                fmt["thinking_format_correct"] and int_has_close
+                            )
+                    len_info = compute_generation_length_info(
+                        raw_gen_text, token_ids=cont_toks
+                    )
+                    # Measure the thinking span only for well-formed responses; the
+                    # corrected `correct` already implies think_token_indices is set.
+                    if fmt.get("thinking_format_correct") == 1:
                         n_think = think_token_indices[-1] + 1
                         think_text = self.tok_decode(
                             cont_toks[:n_think], skip_special_tokens=False
@@ -1581,28 +1615,21 @@ class HFLM(TemplateLM):
                         len_info["thinking_length_tokens"] = n_think
                         len_info["thinking_length_words"] = len(think_text.split())
                         len_info["thinking_length_chars"] = len(think_text)
+                    len_info.update(fmt)
                 else:
-                    len_info = compute_generation_length_info(
+                    # String-close path shares the common builder (format-first).
+                    len_info = build_length_info(
                         raw_gen_text,
                         token_ids=cont_toks,
+                        think_start_token=self.think_start_token,
                         think_end_token=self.think_end_token,
                         tokenizer=self.tokenizer,
+                        open_prefilled=self.think_open_prefilled,
+                        track_thinking_metrics=self.track_thinking_metrics,
                     )
-                # Whether the reasoning block is well-formed. Uses string tokens (the
-                # open from the template / arg; the string close), with the open
-                # searched across prompt+generation since templates prefill it.
-                len_info.update(
-                    compute_thinking_format_info(
-                        raw_gen_text,
-                        context=context,
-                        think_start_token=self.think_start_token,
-                        think_end_token=self.think_end_token_str,
-                    )
-                )
                 length_res.append(len_info)
 
-                # Strip thinking tokens for scoring: keep only tokens after the last
-                # think_end_token occurrence (int mode; reuses the indices above).
+                # Strip thinking for scoring (int mode): keep tokens after the last close.
                 if think_token_indices:
                     cont_toks = cont_toks[think_token_indices[-1] + 1 :]
 
@@ -1626,11 +1653,8 @@ class HFLM(TemplateLM):
                 pbar.update(1)
         # reorder this group of results back to original unsorted form
         res = re_ords.get_original(res)
-        # Carry the parallel length info back to the originating Instances, in the
-        # same (restored) order as `res`; one entry per response, mirroring `resps`.
-        length_res = re_ords.get_original(length_res)
-        for req, info in zip(requests, length_res, strict=True):
-            req.length_info.append(info)
+        # Carry length info back to the Instances, in the same restored order as `res`.
+        attach_length_info(requests, re_ords.get_original(length_res))
 
         pbar.close()
 

--- a/lm_eval/models/huggingface.py
+++ b/lm_eval/models/huggingface.py
@@ -46,6 +46,8 @@ from lm_eval.models.utils import (
     normalize_gen_kwargs,
     postprocess_generated_text,
     resolve_think_tokens,
+    resolve_track_thinking_metrics,
+    truncate_before_stops,
 )
 from lm_eval.models.utils_hf import (
     clear_torch_cache,
@@ -117,9 +119,17 @@ class HFLM(TemplateLM):
         # splits to get response after this token (if provided).
         think_end_token: str | int | None = None,
         # start token for thinking (string) - used for the thinking-format metric.
-        # Auto-detected from the chat template when not set.
+        # Auto-detected from the chat template only with `autodetect_think_tokens`.
         think_start_token: str | None = None,
+        # chat-template argument only; does not affect the strip, detection or metrics.
         enable_thinking: bool | None = None,
+        # opt in to auto-detecting the reasoning tokens from the chat template. Off (the
+        # default) => the template is never scanned, so without an explicit
+        # think_end_token there is no strip and no thinking metrics.
+        autodetect_think_tokens: bool = False,
+        # force the thinking-format/length metrics on/off; None = derive from whether a
+        # reasoning close token is known.
+        track_thinking_metrics: bool | None = None,
         strip_system_boilerplate: bool = False,
         allow_system_boilerplate: bool = False,
         check_system_prompt_authority: bool = False,
@@ -297,27 +307,37 @@ class HFLM(TemplateLM):
                     self.tok_decode([self.think_end_token], skip_special_tokens=False)
                     or None
                 )
-        # Default enable_thinking True (as in vLLM/SGLang); the fail-loud guard still
-        # only fires for reasoning-declaring templates.
+        # Auto-detection is opt-in via `autodetect_think_tokens` (default off); the
+        # fail-loud guard only fires when it is on AND the template declares reasoning
+        # tokens. `enable_thinking` is a chat-template argument and takes no part here.
         self.think_start_token, self.think_end_token_str = resolve_think_tokens(
             _chat_template,
-            self.chat_template_args.get("enable_thinking", True),
+            autodetect_think_tokens,
             think_start_token,
             _forced_close_str,
         )
+        # The strip runs iff a close is known (explicit or auto-detected).
         if self.think_end_token is None:
             self.think_end_token = self.think_end_token_str
+        # The scored text comes from `tok_decode(...)`, which drops special tokens. A
+        # close that it erases could never be found there, so a string strip would
+        # silently never fire. Route such a close through the token-id strip instead.
+        if isinstance(self.think_end_token, str):
+            self.think_end_token = self._strippable_close(self.think_end_token)
 
         # Whether the template prefills the reasoning open into the generation prompt
-        # (vs the model emitting it); feeds the per-turn has_open check.
+        # (vs the model emitting it); feeds the per-turn has_open check. Safe when no open
+        # token is known — detect_open_prefilled returns False.
         self.think_open_prefilled = detect_open_prefilled(
             self.apply_chat_template, self.think_start_token
         )
-        # Track thinking metrics only when thinking is on and a close token is known.
-        # Gate on the *string* close (think_end_token may be an int token id here).
-        self.track_thinking_metrics = bool(
-            self.chat_template_args.get("enable_thinking", True)
-            and self.think_end_token_str
+        # Derived from a known close (int token id or string), unless forced by the
+        # caller. Gating on the *string* form would silently drop every thinking metric
+        # whenever an int close failed to decode, while the strip still fired off the id.
+        # A missing open is fine and degrades the format metric to close-only.
+        self.track_thinking_metrics = resolve_track_thinking_metrics(
+            track_thinking_metrics,
+            self.think_end_token,
         )
 
         # System-prompt authority probe — OFF by default. Run it only when the
@@ -521,6 +541,39 @@ class HFLM(TemplateLM):
             return self.accelerator.unwrap_model(self._model)
         else:
             return self._model
+
+    def _strippable_close(self, close: str) -> str | int:
+        """Return ``close``, or its token id when the scoring decode would erase it.
+
+        The scored text is produced by ``tok_decode(...)``, which defaults to
+        ``skip_special_tokens=True``. A close registered as a *special* token (e.g.
+        DeepSeek-R1's ``</think>``) is dropped there, so ``postprocess_generated_text``
+        could never split on it: the reasoning would silently survive into the scored
+        text, glued to the answer. Falling back to the token id routes the strip through
+        the id-based path, which operates on ids and is unaffected. Never raises.
+
+        Uses ``self.tokenizer`` directly rather than ``tok_encode``/``tok_decode``: this
+        runs early in ``__init__``, before ``self.add_bos_token`` exists.
+        """
+        with contextlib.suppress(Exception):
+            ids = self.tokenizer.encode(close, add_special_tokens=False)
+            if self.tokenizer.decode(ids, skip_special_tokens=True) != "":
+                return close  # survives the scoring decode; the string strip works
+            if len(ids) == 1:
+                eval_logger.info(
+                    "Reasoning close %r is a special token and is dropped by the scoring "
+                    "decode; stripping on its token id (%d) instead.",
+                    close,
+                    ids[0],
+                )
+                return ids[0]
+            eval_logger.warning(
+                "The reasoning close %r is erased by skip_special_tokens and does not map "
+                "to a single token id, so the reasoning strip cannot fire. Pass "
+                "think_end_token=<token id> explicitly.",
+                close,
+            )
+        return close
 
     @property
     def eot_token_id(self) -> int:
@@ -1451,12 +1504,73 @@ class HFLM(TemplateLM):
 
         return re_ord.get_original(res)
 
+    def _bounded_response(
+        self, cont_toks: list[int], until: list[str]
+    ) -> tuple[list[int], str]:
+        """Bound one generated row to the response that sequence actually produced.
+
+        HF's stop criteria halt the *whole batch* only once every sequence is done
+        (``MultiTokenEOSCriteria``), so a row that finished early carries overflow:
+        trailing pad/eos fill, plus real tokens generated past its own stop. Returns the
+        exact original token prefix for this response (never a decode->encode re-encode)
+        and the corresponding text bound.
+
+        Steps: trim the trailing pad/eos tail (never the reasoning close itself), decode,
+        cut at this sequence's own first stop, then map that char bound back onto the
+        token ids by bisect (decoded-prefix length is monotonic in the prefix). Never
+        raises: on any failure it falls back to the unbounded row, i.e. the old behaviour.
+        """
+        bounded: tuple[list[int], str] | None = None
+        with contextlib.suppress(Exception):
+            trimmed = list(cont_toks)
+            stop_ids = {
+                i
+                for i in (
+                    getattr(self.tokenizer, "pad_token_id", None),
+                    self.eot_token_id,
+                )
+                if isinstance(i, int)
+            }
+            # A close that coincides with eos/pad must survive the tail trim, else the
+            # strip and `has_close` would both miss a block the model really did close.
+            if isinstance(self.think_end_token, int):
+                stop_ids.discard(self.think_end_token)
+            while trimmed and trimmed[-1] in stop_ids:
+                trimmed.pop()
+
+            raw_gen_text = self.tok_decode(trimmed, skip_special_tokens=False)
+            gen_text = truncate_before_stops(raw_gen_text, until)
+            if gen_text == raw_gen_text:
+                bounded = (trimmed, gen_text)
+            else:
+                lo, hi = 0, len(trimmed)
+                while lo < hi:
+                    mid = (lo + hi + 1) // 2
+                    fits = len(
+                        self.tok_decode(trimmed[:mid], skip_special_tokens=False)
+                    ) <= len(gen_text)
+                    if fits:
+                        lo = mid
+                    else:
+                        hi = mid - 1
+                bounded = (trimmed[:lo], gen_text)
+        if bounded is not None:
+            return bounded
+
+        # Fallback: the unbounded row (the pre-bounding behaviour).
+        full = ""
+        with contextlib.suppress(Exception):
+            full = self.tok_decode(list(cont_toks), skip_special_tokens=False)
+        return list(cont_toks), full
+
     def generate_until(
         self, requests: list[Instance], disable_tqdm: bool = False
     ) -> list[str]:
         res = []
-        # Parallel to `res`: per-response length measured on the RAW generation
-        # (before the thinking span is stripped), carried back to the Instances.
+        # Parallel to `res`: per-response length/thinking-format, measured on a bounded
+        # view of each generation (trailing pad/eos trimmed, truncated at the first
+        # stop) so batched over-generation past a sequence's own stop is excluded, and
+        # before the thinking span is stripped. Carried back to the Instances.
         length_res = []
 
         def _collate(req: tuple[str, dict]):
@@ -1567,71 +1681,111 @@ class HFLM(TemplateLM):
                 if self.backend == "causal":
                     cont_toks = cont_toks[context_enc.shape[1] :]
 
-                # Thinking boundary indices (int close = token id); reused for the
-                # length info and the strip below.
-                think_token_indices = (
-                    [i for i, t in enumerate(cont_toks) if t == self.think_end_token]
+                # Bound this sequence to its OWN response before anything reads it.
+                # Batched generation runs until EVERY sequence in the batch stops
+                # (MultiTokenEOSCriteria halts the whole batch), so a sequence that
+                # finished early carries "overflow": trailing pad/eos fill, plus real
+                # tokens generated past its own stop. `meas_toks` is an exact prefix of
+                # `cont_toks`; `gen_text` is its text bound. Never raises.
+                meas_toks, gen_text = self._bounded_response(cont_toks, until)
+
+                # Positions of the int close WITHIN this sequence's own response. The
+                # scoring strip and the metric both read this list, so they can never
+                # disagree about whether the block closed — and a close that exists only
+                # in a batch sibling's overflow can no longer be stripped on.
+                closes = (
+                    [i for i, t in enumerate(meas_toks) if t == self.think_end_token]
                     if isinstance(self.think_end_token, int)
                     else None
                 )
 
-                # Length of the RAW generation, before the strip below.
-                raw_gen_text = self.tok_decode(cont_toks, skip_special_tokens=False)
-                if isinstance(self.think_end_token, int):
-                    # Int-token path: builds the same length+format dict as
-                    # build_length_info but with a token-id thinking span instead of a
-                    # string one — keep the two in sync on any length/format change.
-                    # Format uses the string close, but has_close / correct MUST reflect
-                    # the int-token boundary the strip actually uses (below), so the
-                    # metric never claims well-formed while the strip is skipped
-                    # (string/int tokenizations can disagree).
-                    fmt = (
-                        compute_thinking_format_info(
-                            raw_gen_text,
-                            think_start_token=self.think_start_token,
-                            think_end_token=self.think_end_token_str,
-                            open_prefilled=self.think_open_prefilled,
-                        )
-                        if self.track_thinking_metrics
-                        else {}
-                    )
-                    if fmt:
-                        int_has_close = bool(think_token_indices)
-                        fmt["thinking_format_has_close"] = int(int_has_close)
-                        if "thinking_format_correct" in fmt:
-                            fmt["thinking_format_correct"] = int(
-                                fmt["thinking_format_correct"] and int_has_close
+                # --- Per-response length/format measurement ---
+                # Measured on the bounded view so the flags reflect THIS sequence's
+                # response and are not polluted by longer batch siblings (matching
+                # vllm/sglang, which stop each sequence independently). Never raises —
+                # measurement must not break generation.
+                len_info: dict = {}
+                with contextlib.suppress(Exception):
+                    if isinstance(self.think_end_token, int):
+                        # Int-token path: same length+format dict as build_length_info but
+                        # with a token-id thinking span — keep the two in sync on any
+                        # length/format change. has_close and the span come from `closes`
+                        # (exact ids, overflow-free), so they are batch-invariant and they
+                        # are the very indices the scoring strip uses. Order/re-open is
+                        # judged on `gen_text`, using the close as it renders IN CONTEXT:
+                        # `think_end_token_str` is decoded from the id in isolation and can
+                        # differ (leading space, merge), which would make the string search
+                        # miss and flag a well-formed response as malformed.
+                        close_str = self.think_end_token_str
+                        if closes:
+                            end = len(
+                                self.tok_decode(
+                                    meas_toks[: closes[-1] + 1],
+                                    skip_special_tokens=False,
+                                )
                             )
-                    len_info = compute_generation_length_info(
-                        raw_gen_text, token_ids=cont_toks
-                    )
-                    # Measure the thinking span only for well-formed responses; the
-                    # corrected `correct` already implies think_token_indices is set.
-                    if fmt.get("thinking_format_correct") == 1:
-                        n_think = think_token_indices[-1] + 1
-                        think_text = self.tok_decode(
-                            cont_toks[:n_think], skip_special_tokens=False
+                            start = len(
+                                self.tok_decode(
+                                    meas_toks[: closes[-1]], skip_special_tokens=False
+                                )
+                            )
+                            close_str = gen_text[start:end] or close_str
+                        fmt = (
+                            compute_thinking_format_info(
+                                gen_text,
+                                think_start_token=self.think_start_token,
+                                think_end_token=close_str,
+                                open_prefilled=self.think_open_prefilled,
+                            )
+                            if self.track_thinking_metrics
+                            else {}
                         )
-                        len_info["thinking_length_tokens"] = n_think
-                        len_info["thinking_length_words"] = len(think_text.split())
-                        len_info["thinking_length_chars"] = len(think_text)
-                    len_info.update(fmt)
-                else:
-                    # String-close path shares the common builder (format-first).
-                    len_info = build_length_info(
-                        raw_gen_text,
-                        token_ids=cont_toks,
-                        think_start_token=self.think_start_token,
-                        think_end_token=self.think_end_token,
-                        tokenizer=self.tokenizer,
-                        open_prefilled=self.think_open_prefilled,
-                        track_thinking_metrics=self.track_thinking_metrics,
-                    )
+                        if self.track_thinking_metrics:
+                            # The int boundary is authoritative for has_close; `correct`
+                            # keeps the order/re-open verdict, and degrades to close-only
+                            # when no usable close string was available.
+                            int_has_close = bool(closes)
+                            fmt["thinking_format_has_close"] = int(int_has_close)
+                            prior = fmt.get("thinking_format_correct")
+                            if prior is None:
+                                prior = fmt.get("thinking_format_has_open", 1)
+                            fmt["thinking_format_correct"] = int(
+                                bool(prior) and int_has_close
+                            )
+                        len_info = compute_generation_length_info(
+                            gen_text, token_ids=meas_toks
+                        )
+                        # Thinking span = up to and including the last close; `correct`
+                        # already implies `closes` is non-empty.
+                        if fmt.get("thinking_format_correct") == 1:
+                            n_think = closes[-1] + 1
+                            think_text = self.tok_decode(
+                                meas_toks[:n_think], skip_special_tokens=False
+                            )
+                            len_info["thinking_length_tokens"] = n_think
+                            len_info["thinking_length_words"] = len(think_text.split())
+                            len_info["thinking_length_chars"] = len(think_text)
+                        len_info.update(fmt)
+                    else:
+                        # String-close path shares the common builder (format-first).
+                        len_info = build_length_info(
+                            gen_text,
+                            token_ids=meas_toks,
+                            think_start_token=self.think_start_token,
+                            think_end_token=self.think_end_token,
+                            tokenizer=self.tokenizer,
+                            open_prefilled=self.think_open_prefilled,
+                            track_thinking_metrics=self.track_thinking_metrics,
+                        )
                 length_res.append(len_info)
 
-                # Strip thinking for scoring (int mode): keep tokens after the last close.
-                if think_token_indices:
-                    cont_toks = cont_toks[think_token_indices[-1] + 1 :]
+                # Strip thinking for scoring (int mode): keep tokens after the last
+                # IN-BOUNDS close. `closes` indexes `meas_toks`, itself a prefix of
+                # `cont_toks`, so the indices are valid here and a close that only
+                # appears in batch overflow can never drive the strip. Everything after
+                # the close is kept; `postprocess_generated_text` truncates at the stop.
+                if closes:
+                    cont_toks = cont_toks[closes[-1] + 1 :]
 
                 s = self.tok_decode(cont_toks)
 

--- a/lm_eval/models/huggingface.py
+++ b/lm_eval/models/huggingface.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import contextlib
 import logging
 import os
 from datetime import timedelta
@@ -33,14 +34,15 @@ from lm_eval.models.utils import (
     _add_special_kwargs,
     check_system_boilerplate,
     compute_generation_length_info,
+    compute_thinking_format_info,
     configure_pad_token,
-    detect_think_end_token,
     get_template_special_tokens,
     handle_stop_sequences,
     has_bos_prefix,
     maybe_strip_system_boilerplate,
     normalize_gen_kwargs,
     postprocess_generated_text,
+    resolve_think_tokens,
 )
 from lm_eval.models.utils_hf import (
     clear_torch_cache,
@@ -111,6 +113,9 @@ class HFLM(TemplateLM):
         # end token for thinking, either the string or int token id.
         # splits to get response after this token (if provided).
         think_end_token: str | int | None = None,
+        # start token for thinking (string) - used for the thinking-format metric.
+        # Auto-detected from the chat template when not set.
+        think_start_token: str | None = None,
         enable_thinking: bool | None = None,
         strip_system_boilerplate: bool = False,
         allow_system_boilerplate: bool = False,
@@ -275,13 +280,34 @@ class HFLM(TemplateLM):
         if enable_thinking is not None:
             self.chat_template_args["enable_thinking"] = enable_thinking
 
-        # Default the reasoning-strip token from the model's chat template when the
-        # caller didn't set it explicitly (a string close token; the int/str handling
-        # above only applies to an explicitly-passed token).
+        # Resolve the reasoning open/close tokens from the model's chat template when
+        # the caller didn't set them. self.think_end_token may be an int (token id)
+        # used by the token-level strip below; self.think_end_token_str is always the
+        # *string* close used by the thinking-format metric — including when an int
+        # token id was supplied, in which case we decode it so the format metric and
+        # the strip reference the same boundary (and so a valid int close never
+        # triggers the fail-loud guard meant for an unresolvable close).
+        _chat_template = getattr(self.tokenizer, "chat_template", None)
+        _forced_close_str = None
+        if isinstance(self.think_end_token, str):
+            _forced_close_str = self.think_end_token
+        elif isinstance(self.think_end_token, int):
+            with contextlib.suppress(Exception):
+                _forced_close_str = (
+                    self.tok_decode([self.think_end_token], skip_special_tokens=False)
+                    or None
+                )
+        # Default to True (like vLLM/SGLang) so the fail-loud close-token guard is
+        # consistent across backends: it still only fires for reasoning-declaring
+        # templates, and a user can disable it with enable_thinking=False.
+        self.think_start_token, self.think_end_token_str = resolve_think_tokens(
+            _chat_template,
+            self.chat_template_args.get("enable_thinking", True),
+            think_start_token,
+            _forced_close_str,
+        )
         if self.think_end_token is None:
-            self.think_end_token = detect_think_end_token(
-                getattr(self.tokenizer, "chat_template", None)
-            )
+            self.think_end_token = self.think_end_token_str
 
         # System-prompt authority probe — OFF by default. Run it only when the
         # caller opts in via `check_system_prompt_authority` (and hasn't waived it with
@@ -1541,9 +1567,10 @@ class HFLM(TemplateLM):
                 # Length of the RAW generation (full cont_toks, before the thinking
                 # span is stripped below), for per-sample logging. think_end_token may
                 # be a token id (int) or a string; both mark the same boundary.
+                raw_gen_text = self.tok_decode(cont_toks, skip_special_tokens=False)
                 if isinstance(self.think_end_token, int):
                     len_info = compute_generation_length_info(
-                        self.tok_decode(cont_toks, skip_special_tokens=False),
+                        raw_gen_text,
                         token_ids=cont_toks,
                     )
                     if think_token_indices:
@@ -1554,16 +1581,25 @@ class HFLM(TemplateLM):
                         len_info["thinking_length_tokens"] = n_think
                         len_info["thinking_length_words"] = len(think_text.split())
                         len_info["thinking_length_chars"] = len(think_text)
-                    length_res.append(len_info)
                 else:
-                    length_res.append(
-                        compute_generation_length_info(
-                            self.tok_decode(cont_toks, skip_special_tokens=False),
-                            token_ids=cont_toks,
-                            think_end_token=self.think_end_token,
-                            tokenizer=self.tokenizer,
-                        )
+                    len_info = compute_generation_length_info(
+                        raw_gen_text,
+                        token_ids=cont_toks,
+                        think_end_token=self.think_end_token,
+                        tokenizer=self.tokenizer,
                     )
+                # Whether the reasoning block is well-formed. Uses string tokens (the
+                # open from the template / arg; the string close), with the open
+                # searched across prompt+generation since templates prefill it.
+                len_info.update(
+                    compute_thinking_format_info(
+                        raw_gen_text,
+                        context=context,
+                        think_start_token=self.think_start_token,
+                        think_end_token=self.think_end_token_str,
+                    )
+                )
+                length_res.append(len_info)
 
                 # Strip thinking tokens for scoring: keep only tokens after the last
                 # think_end_token occurrence (int mode; reuses the indices above).

--- a/lm_eval/models/huggingface.py
+++ b/lm_eval/models/huggingface.py
@@ -32,7 +32,9 @@ from lm_eval.models.utils import (
     Collator,
     _add_special_kwargs,
     check_system_boilerplate,
+    compute_generation_length_info,
     configure_pad_token,
+    detect_think_end_token,
     get_template_special_tokens,
     handle_stop_sequences,
     has_bos_prefix,
@@ -272,6 +274,14 @@ class HFLM(TemplateLM):
         self.chat_template_args = chat_template_args
         if enable_thinking is not None:
             self.chat_template_args["enable_thinking"] = enable_thinking
+
+        # Default the reasoning-strip token from the model's chat template when the
+        # caller didn't set it explicitly (a string close token; the int/str handling
+        # above only applies to an explicitly-passed token).
+        if self.think_end_token is None:
+            self.think_end_token = detect_think_end_token(
+                getattr(self.tokenizer, "chat_template", None)
+            )
 
         # System-prompt authority probe — OFF by default. Run it only when the
         # caller opts in via `check_system_prompt_authority` (and hasn't waived it with
@@ -1408,6 +1418,9 @@ class HFLM(TemplateLM):
         self, requests: list[Instance], disable_tqdm: bool = False
     ) -> list[str]:
         res = []
+        # Parallel to `res`: per-response length measured on the RAW generation
+        # (before the thinking span is stripped), carried back to the Instances.
+        length_res = []
 
         def _collate(req: tuple[str, dict]):
             """Defines the key for the sorted method"""
@@ -1517,15 +1530,45 @@ class HFLM(TemplateLM):
                 if self.backend == "causal":
                     cont_toks = cont_toks[context_enc.shape[1] :]
 
-                # Handle integer think_end_token: find last occurrence and strip tokens after it
+                # Locate the thinking boundary once (int think_end_token = token id);
+                # reused for both length logging and the strip below.
+                think_token_indices = (
+                    [i for i, t in enumerate(cont_toks) if t == self.think_end_token]
+                    if isinstance(self.think_end_token, int)
+                    else None
+                )
+
+                # Length of the RAW generation (full cont_toks, before the thinking
+                # span is stripped below), for per-sample logging. think_end_token may
+                # be a token id (int) or a string; both mark the same boundary.
                 if isinstance(self.think_end_token, int):
-                    think_token_indices = [
-                        i
-                        for i, token in enumerate(cont_toks)
-                        if token == self.think_end_token
-                    ]
+                    len_info = compute_generation_length_info(
+                        self.tok_decode(cont_toks, skip_special_tokens=False),
+                        token_ids=cont_toks,
+                    )
                     if think_token_indices:
-                        cont_toks = cont_toks[think_token_indices[-1] + 1 :]
+                        n_think = think_token_indices[-1] + 1
+                        think_text = self.tok_decode(
+                            cont_toks[:n_think], skip_special_tokens=False
+                        )
+                        len_info["thinking_length_tokens"] = n_think
+                        len_info["thinking_length_words"] = len(think_text.split())
+                        len_info["thinking_length_chars"] = len(think_text)
+                    length_res.append(len_info)
+                else:
+                    length_res.append(
+                        compute_generation_length_info(
+                            self.tok_decode(cont_toks, skip_special_tokens=False),
+                            token_ids=cont_toks,
+                            think_end_token=self.think_end_token,
+                            tokenizer=self.tokenizer,
+                        )
+                    )
+
+                # Strip thinking tokens for scoring: keep only tokens after the last
+                # think_end_token occurrence (int mode; reuses the indices above).
+                if think_token_indices:
+                    cont_toks = cont_toks[think_token_indices[-1] + 1 :]
 
                 s = self.tok_decode(cont_toks)
 
@@ -1547,6 +1590,11 @@ class HFLM(TemplateLM):
                 pbar.update(1)
         # reorder this group of results back to original unsorted form
         res = re_ords.get_original(res)
+        # Carry the parallel length info back to the originating Instances, in the
+        # same (restored) order as `res`; one entry per response, mirroring `resps`.
+        length_res = re_ords.get_original(length_res)
+        for req, info in zip(requests, length_res, strict=True):
+            req.length_info.append(info)
 
         pbar.close()
 

--- a/lm_eval/models/sglang_causallms.py
+++ b/lm_eval/models/sglang_causallms.py
@@ -16,6 +16,7 @@ from lm_eval.models.utils import (
     handle_stop_sequences,
     postprocess_generated_text,
     resolve_think_tokens,
+    resolve_track_thinking_metrics,
 )
 from lm_eval.utils import (
     get_rolling_token_windows,
@@ -67,8 +68,16 @@ class SGLangLM(TemplateLM):
         # End marker for thinking tags - splits to get response after this token (if provided).
         think_end_token: str | None = None,
         # Start marker for thinking tags - used for the thinking-format metric. Auto-
-        # detected from the chat template when not set.
+        # detected from the chat template only with `autodetect_think_tokens`.
         think_start_token: str | None = None,
+        # opt in to auto-detecting the reasoning tokens from the chat template. Off (the
+        # default) => the template is never scanned, so without an explicit
+        # think_end_token there is no strip and no thinking metrics. Must be a named
+        # parameter: `**kwargs` is forwarded verbatim to `sgl.Engine`.
+        autodetect_think_tokens: bool = False,
+        # force the thinking-format/length metrics on/off; None = derive (on whenever a
+        # reasoning close token is known).
+        track_thinking_metrics: bool | None = None,
         **kwargs,
     ):
         super().__init__()
@@ -120,25 +129,29 @@ class SGLangLM(TemplateLM):
 
         # Todo(Jinwei): check tokenizer and other settings.
         self.tokenizer = self.model.tokenizer_manager.tokenizer
-        # Auto-detect open/close tokens from the chat template when not forced. SGLang
-        # has no enable_thinking toggle, so a reasoning-declaring template is treated
-        # as thinking-intended (fail loud if its tokens can't be resolved).
+        # Auto-detect open/close tokens from the chat template when opted in and not
+        # forced. When on, fails loud if the template declares reasoning tokens but the
+        # close can't be resolved; pass `think_end_token=` or drop the opt-in to escape.
+        # The strip then runs iff a close is known.
         _chat_template = getattr(self.tokenizer, "chat_template", None)
         self.think_start_token, self.think_end_token = resolve_think_tokens(
             _chat_template,
-            enable_thinking=True,
+            autodetect=autodetect_think_tokens,
             think_start_token=self.think_start_token,
             think_end_token=self.think_end_token,
         )
         # Whether the template prefills the reasoning open into the generation prompt
-        # (vs the model emitting it); feeds the per-turn has_open check. SGLang's
-        # apply_chat_template is enable_thinking-agnostic, so this reflects its own
-        # rendering. Track thinking metrics whenever a close token is known (SGLang has
-        # no enable_thinking toggle — it is always on).
+        # (vs the model emitting it); feeds the per-turn has_open check. Returns False
+        # when no open token is known.
         self.think_open_prefilled = detect_open_prefilled(
             self.apply_chat_template, self.think_start_token
         )
-        self.track_thinking_metrics = bool(self.think_end_token)
+        # Derived from a known close, unless forced by the caller. A missing open is fine
+        # and degrades the format metric to close-only.
+        self.track_thinking_metrics = resolve_track_thinking_metrics(
+            track_thinking_metrics,
+            think_end_token=self.think_end_token,
+        )
         self._max_gen_toks = max_gen_toks
         self.add_bos_token = add_bos_token
         if "gemma" in pretrained.lower():

--- a/lm_eval/models/sglang_causallms.py
+++ b/lm_eval/models/sglang_causallms.py
@@ -1,7 +1,7 @@
 import copy
 import logging
 from importlib.util import find_spec
-from typing import TYPE_CHECKING, Dict, List, Optional, Tuple, Union
+from typing import TYPE_CHECKING
 
 from tqdm import tqdm
 
@@ -11,9 +11,10 @@ from lm_eval.api.registry import register_model
 from lm_eval.models.utils import (
     Collator,
     compute_generation_length_info,
-    detect_think_end_token,
+    compute_thinking_format_info,
     handle_stop_sequences,
     postprocess_generated_text,
+    resolve_think_tokens,
 )
 from lm_eval.utils import (
     get_rolling_token_windows,
@@ -40,30 +41,33 @@ class SGLangLM(TemplateLM):
         self,
         pretrained: str,
         # batch args from lm-eval interface:  https://github.com/EleutherAI/lm-evaluation-harness/blob/main/docs/interface.md
-        batch_size: Union[str, int] = 1,
+        batch_size: str | int = 1,
         max_batch_size=None,
         max_model_len: int = None,
         max_gen_toks: int = 256,
-        add_bos_token: Optional[bool] = False,
+        add_bos_token: bool | None = False,
         ########## SGlang native args ##########
         # Todo(Jinwei): Include more args of SGLang Engine if needed. Refer to https://docs.sglang.ai/backend/server_arguments.html .
-        tokenizer_path: Optional[str] = None,
+        tokenizer_path: str | None = None,
         tokenizer_mode: str = "auto",
         load_format: str = "auto",
         trust_remote_code: bool = True,
         dtype: str = "auto",
         kv_cache_dtype: str = "auto",
-        context_length: Optional[int] = None,
+        context_length: int | None = None,
         device: str = "cuda",
         chunked_prefill_size: int = -1,
         # Memory and scheduling
-        mem_fraction_static: Optional[float] = None,
+        mem_fraction_static: float | None = None,
         # parallelism
         dp_size: int = 1,
         tp_size: int = 1,
-        prefix_token_id: Optional[int] = None,
+        prefix_token_id: int | None = None,
         # End marker for thinking tags - splits to get response after this token (if provided).
-        think_end_token: Optional[str] = None,
+        think_end_token: str | None = None,
+        # Start marker for thinking tags - used for the thinking-format metric. Auto-
+        # detected from the chat template when not set.
+        think_start_token: str | None = None,
         **kwargs,
     ):
         super().__init__()
@@ -80,6 +84,7 @@ class SGLangLM(TemplateLM):
         )
         # Initialize your sglang model here
         self.think_end_token = think_end_token
+        self.think_start_token = think_start_token
         self._max_length = (
             max_model_len if max_model_len is not None else context_length
         )
@@ -114,11 +119,17 @@ class SGLangLM(TemplateLM):
 
         # Todo(Jinwei): check tokenizer and other settings.
         self.tokenizer = self.model.tokenizer_manager.tokenizer
-        # Default the reasoning-strip token from the chat template when caller unset it.
-        if self.think_end_token is None:
-            self.think_end_token = detect_think_end_token(
-                getattr(self.tokenizer, "chat_template", None)
-            )
+        # Default the reasoning open/close tokens from the chat template when the
+        # caller didn't set them. SGLang has no enable_thinking toggle, so treat a
+        # template that declares reasoning tokens as thinking-intended (fail loud if
+        # such a template's tokens can't be resolved).
+        _chat_template = getattr(self.tokenizer, "chat_template", None)
+        self.think_start_token, self.think_end_token = resolve_think_tokens(
+            _chat_template,
+            enable_thinking=True,
+            think_start_token=self.think_start_token,
+            think_end_token=self.think_end_token,
+        )
         self._max_gen_toks = max_gen_toks
         self.add_bos_token = add_bos_token
         if "gemma" in pretrained.lower():
@@ -129,8 +140,8 @@ class SGLangLM(TemplateLM):
         self.custom_prefix_token_id = prefix_token_id
 
     def loglikelihood_rolling(
-        self, requests: List[Instance], disable_tqdm: bool = False
-    ) -> List[float]:
+        self, requests: list[Instance], disable_tqdm: bool = False
+    ) -> list[float]:
         adaptive_batch_size = None
         if self.batch_size == "auto":
             adaptive_batch_size = len(requests)
@@ -145,7 +156,7 @@ class SGLangLM(TemplateLM):
                 disable=(disable_tqdm or (self.rank != 0)),
             )
         ):
-            rolling_token_windows: List[Tuple[List[int], List[int]]] = list(
+            rolling_token_windows: list[tuple[list[int], list[int]]] = list(
                 map(
                     make_disjoint_window,
                     get_rolling_token_windows(
@@ -198,8 +209,8 @@ class SGLangLM(TemplateLM):
         return loglikelihoods
 
     def generate_until(
-        self, requests: List[Instance], disable_tqdm: bool = False
-    ) -> List[str]:
+        self, requests: list[Instance], disable_tqdm: bool = False
+    ) -> list[str]:
         res = []
         # Keep the original Instances (the `requests` name is reassigned below) and a
         # parallel length list, so generation length can be carried back per sample.
@@ -208,7 +219,7 @@ class SGLangLM(TemplateLM):
 
         # batch tokenize contexts
         context, all_gen_kwargs = zip(*(req.args for req in requests))
-        context_encoding: List[List[int]] = self.tok_encode(
+        context_encoding: list[list[int]] = self.tok_encode(
             context, add_special_tokens=self.add_bos_token
         )
         requests = [
@@ -295,6 +306,16 @@ class SGLangLM(TemplateLM):
                 _ct = (output.get("meta_info") or {}).get("completion_tokens")
                 if isinstance(_ct, int):
                     _len_info["response_length_tokens"] = _ct
+                # Whether the reasoning block is well-formed (open in prompt+gen,
+                # close in gen).
+                _len_info.update(
+                    compute_thinking_format_info(
+                        generated_text,
+                        context=context,
+                        think_start_token=self.think_start_token,
+                        think_end_token=self.think_end_token,
+                    )
+                )
                 length_res.append(_len_info)
                 generated_text = postprocess_generated_text(
                     generated_text, until, self.think_end_token
@@ -317,9 +338,9 @@ class SGLangLM(TemplateLM):
 
     def _model_generate(
         self,
-        requests: List[List[int]] = None,
+        requests: list[list[int]] = None,
         generate: bool = False,
-        sampling_params: Union[List[Dict], Dict, None] = None,
+        sampling_params: list[dict] | dict | None = None,
         return_logprob: bool = False,
         top_logprobs_num: int = 1,
         logprob_start_len: int = -1,
@@ -333,7 +354,7 @@ class SGLangLM(TemplateLM):
                     "max_new_tokens": 1,
                 }
             )
-        if not isinstance(sampling_params, List):
+        if not isinstance(sampling_params, list):
             sampling_params = [sampling_params] * len(requests)
         # Refer to:  https://docs.sglang.ai/backend/offline_engine_api.html
         outputs = self.model.generate(
@@ -376,14 +397,14 @@ class SGLangLM(TemplateLM):
 
     def tok_encode(
         self,
-        string: Union[str, List[str]],
+        string: str | list[str],
         left_truncate_len: int = None,
         add_special_tokens: bool = False,
         truncation: bool = False,
-    ) -> Union[List[int], List[List[int]]]:
+    ) -> list[int] | list[list[int]]:
         if not add_special_tokens:
             add_special_tokens = False or self.add_bos_token
-        encoding: Union[List[List[int]], List[int]] = self.tokenizer(
+        encoding: list[list[int]] | list[int] = self.tokenizer(
             string,
             add_special_tokens=add_special_tokens,
             truncation=truncation,
@@ -399,7 +420,7 @@ class SGLangLM(TemplateLM):
 
         return encoding
 
-    def tok_decode(self, tokens: List[int]) -> str:
+    def tok_decode(self, tokens: list[int]) -> str:
         # Implement token-to-text decoding
         pass
 
@@ -414,7 +435,7 @@ class SGLangLM(TemplateLM):
         """
         pass
 
-    def chat_template(self, chat_template: Union[bool, str] = False) -> str:
+    def chat_template(self, chat_template: bool | str = False) -> str:
         """
         Get the appropriate chat template for the model based on the `chat_template` argument.
 
@@ -436,7 +457,7 @@ class SGLangLM(TemplateLM):
         pass
 
     def apply_chat_template(
-        self, chat_history: List[Dict[str, str]], add_generation_prompt: bool = True
+        self, chat_history: list[dict[str, str]], add_generation_prompt: bool = True
     ) -> str:
         """
         Method to apply a chat template to a list of chat history between user and model.
@@ -452,9 +473,9 @@ class SGLangLM(TemplateLM):
 
     def _loglikelihood_tokens(
         self,
-        requests: List[Tuple[Tuple[str, str], List[int], List[int]]],
+        requests: list[tuple[tuple[str, str], list[int], list[int]]],
         disable_tqdm: bool = False,
-    ) -> List[Tuple[float, bool]]:
+    ) -> list[tuple[float, bool]]:
         res = []
 
         def _collate(x):
@@ -510,7 +531,7 @@ class SGLangLM(TemplateLM):
         return re_ord.get_original(res)
 
     @staticmethod
-    def _parse_logprobs(tokens: List, outputs, ctxlen: int) -> Tuple[float, bool]:
+    def _parse_logprobs(tokens: list, outputs, ctxlen: int) -> tuple[float, bool]:
         """Process logprobs and tokens.
 
         :param tokens: list

--- a/lm_eval/models/sglang_causallms.py
+++ b/lm_eval/models/sglang_causallms.py
@@ -10,6 +10,8 @@ from lm_eval.api.model import TemplateLM
 from lm_eval.api.registry import register_model
 from lm_eval.models.utils import (
     Collator,
+    compute_generation_length_info,
+    detect_think_end_token,
     handle_stop_sequences,
     postprocess_generated_text,
 )
@@ -112,6 +114,11 @@ class SGLangLM(TemplateLM):
 
         # Todo(Jinwei): check tokenizer and other settings.
         self.tokenizer = self.model.tokenizer_manager.tokenizer
+        # Default the reasoning-strip token from the chat template when caller unset it.
+        if self.think_end_token is None:
+            self.think_end_token = detect_think_end_token(
+                getattr(self.tokenizer, "chat_template", None)
+            )
         self._max_gen_toks = max_gen_toks
         self.add_bos_token = add_bos_token
         if "gemma" in pretrained.lower():
@@ -194,6 +201,10 @@ class SGLangLM(TemplateLM):
         self, requests: List[Instance], disable_tqdm: bool = False
     ) -> List[str]:
         res = []
+        # Keep the original Instances (the `requests` name is reassigned below) and a
+        # parallel length list, so generation length can be carried back per sample.
+        instances = requests
+        length_res = []
 
         # batch tokenize contexts
         context, all_gen_kwargs = zip(*(req.args for req in requests))
@@ -272,6 +283,19 @@ class SGLangLM(TemplateLM):
             # cache generations
             for output, context in zip(cont, context):
                 generated_text = output.get("text", "")
+                # Length on the RAW generation (before the thinking span is stripped).
+                # sglang returns no token_ids here; use the exact completion_tokens
+                # count from meta_info when present for response_length_tokens.
+                _len_info = compute_generation_length_info(
+                    generated_text,
+                    token_ids=None,
+                    think_end_token=self.think_end_token,
+                    tokenizer=self.tokenizer,
+                )
+                _ct = (output.get("meta_info") or {}).get("completion_tokens")
+                if isinstance(_ct, int):
+                    _len_info["response_length_tokens"] = _ct
+                length_res.append(_len_info)
                 generated_text = postprocess_generated_text(
                     generated_text, until, self.think_end_token
                 )
@@ -283,7 +307,13 @@ class SGLangLM(TemplateLM):
 
         pbar.close()
         # reorder all group of results back to original unsorted form
-        return re_ords.get_original(res)
+        res = re_ords.get_original(res)
+        # Carry the parallel length info back to the original Instances, in the same
+        # (restored) order as `res`; one entry per response, mirroring `resps`.
+        length_res = re_ords.get_original(length_res)
+        for req, info in zip(instances, length_res, strict=True):
+            req.length_info.append(info)
+        return res
 
     def _model_generate(
         self,

--- a/lm_eval/models/sglang_causallms.py
+++ b/lm_eval/models/sglang_causallms.py
@@ -10,8 +10,9 @@ from lm_eval.api.model import TemplateLM
 from lm_eval.api.registry import register_model
 from lm_eval.models.utils import (
     Collator,
-    compute_generation_length_info,
-    compute_thinking_format_info,
+    attach_length_info,
+    build_length_info,
+    detect_open_prefilled,
     handle_stop_sequences,
     postprocess_generated_text,
     resolve_think_tokens,
@@ -119,10 +120,9 @@ class SGLangLM(TemplateLM):
 
         # Todo(Jinwei): check tokenizer and other settings.
         self.tokenizer = self.model.tokenizer_manager.tokenizer
-        # Default the reasoning open/close tokens from the chat template when the
-        # caller didn't set them. SGLang has no enable_thinking toggle, so treat a
-        # template that declares reasoning tokens as thinking-intended (fail loud if
-        # such a template's tokens can't be resolved).
+        # Auto-detect open/close tokens from the chat template when not forced. SGLang
+        # has no enable_thinking toggle, so a reasoning-declaring template is treated
+        # as thinking-intended (fail loud if its tokens can't be resolved).
         _chat_template = getattr(self.tokenizer, "chat_template", None)
         self.think_start_token, self.think_end_token = resolve_think_tokens(
             _chat_template,
@@ -130,6 +130,15 @@ class SGLangLM(TemplateLM):
             think_start_token=self.think_start_token,
             think_end_token=self.think_end_token,
         )
+        # Whether the template prefills the reasoning open into the generation prompt
+        # (vs the model emitting it); feeds the per-turn has_open check. SGLang's
+        # apply_chat_template is enable_thinking-agnostic, so this reflects its own
+        # rendering. Track thinking metrics whenever a close token is known (SGLang has
+        # no enable_thinking toggle — it is always on).
+        self.think_open_prefilled = detect_open_prefilled(
+            self.apply_chat_template, self.think_start_token
+        )
+        self.track_thinking_metrics = bool(self.think_end_token)
         self._max_gen_toks = max_gen_toks
         self.add_bos_token = add_bos_token
         if "gemma" in pretrained.lower():
@@ -212,8 +221,8 @@ class SGLangLM(TemplateLM):
         self, requests: list[Instance], disable_tqdm: bool = False
     ) -> list[str]:
         res = []
-        # Keep the original Instances (the `requests` name is reassigned below) and a
-        # parallel length list, so generation length can be carried back per sample.
+        # Keep the original Instances (`requests` is reassigned below) to carry length
+        # info back per sample.
         instances = requests
         length_res = []
 
@@ -294,29 +303,23 @@ class SGLangLM(TemplateLM):
             # cache generations
             for output, context in zip(cont, context):
                 generated_text = output.get("text", "")
-                # Length on the RAW generation (before the thinking span is stripped).
-                # sglang returns no token_ids here; use the exact completion_tokens
-                # count from meta_info when present for response_length_tokens.
-                _len_info = compute_generation_length_info(
+                # Per-response length + current-turn thinking-format (format-first, so
+                # the thinking span is measured only for well-formed responses).
+                len_info = build_length_info(
                     generated_text,
                     token_ids=None,
+                    think_start_token=self.think_start_token,
                     think_end_token=self.think_end_token,
                     tokenizer=self.tokenizer,
+                    open_prefilled=self.think_open_prefilled,
+                    track_thinking_metrics=self.track_thinking_metrics,
                 )
+                # sglang returns no token_ids -> take the exact response token count
+                # from meta_info when present.
                 _ct = (output.get("meta_info") or {}).get("completion_tokens")
                 if isinstance(_ct, int):
-                    _len_info["response_length_tokens"] = _ct
-                # Whether the reasoning block is well-formed (open in prompt+gen,
-                # close in gen).
-                _len_info.update(
-                    compute_thinking_format_info(
-                        generated_text,
-                        context=context,
-                        think_start_token=self.think_start_token,
-                        think_end_token=self.think_end_token,
-                    )
-                )
-                length_res.append(_len_info)
+                    len_info["response_length_tokens"] = _ct
+                length_res.append(len_info)
                 generated_text = postprocess_generated_text(
                     generated_text, until, self.think_end_token
                 )
@@ -329,11 +332,8 @@ class SGLangLM(TemplateLM):
         pbar.close()
         # reorder all group of results back to original unsorted form
         res = re_ords.get_original(res)
-        # Carry the parallel length info back to the original Instances, in the same
-        # (restored) order as `res`; one entry per response, mirroring `resps`.
-        length_res = re_ords.get_original(length_res)
-        for req, info in zip(instances, length_res, strict=True):
-            req.length_info.append(info)
+        # Carry length info back to the Instances, in the same restored order as `res`.
+        attach_length_info(instances, re_ords.get_original(length_res))
         return res
 
     def _model_generate(

--- a/lm_eval/models/utils.py
+++ b/lm_eval/models/utils.py
@@ -1196,6 +1196,152 @@ def compute_generation_length_info(
     return info
 
 
+def compute_thinking_format_info(
+    generation: str,
+    context: str | None = None,
+    think_start_token: str | None = None,
+    think_end_token: str | None = None,
+) -> dict:
+    """Whether a generation's reasoning (think) block is well-formed.
+
+    Returns 0/1 flags for per-sample logging (aggregated to a per-task rate):
+
+    - ``thinking_format_has_open``  — the open token is present in the prompt OR the
+      generation. Thinking templates usually *prefill* the open token into the
+      prompt (so the model emits only the close), hence the open is searched across
+      ``context + generation``; a model that emits its own open is covered too.
+      (For prefill templates this is ~always 1 — it still flags the case where the
+      block was never opened, e.g. a non-thinking path.)
+    - ``thinking_format_has_close`` — the close token is present in the generation
+      (the model must actually emit it).
+    - ``thinking_format_correct``   — open present, close present, open precedes the
+      close, AND the block is not re-opened after the close (catches a stray second
+      open such as ``</think>...<think>...`` that would otherwise pass a bare
+      open<close ordering check when the open is prefilled).
+
+    A flag is only emitted when its token is known, mirroring how
+    ``thinking_length_*`` is gated. Never raises — format logging must not break
+    generation.
+
+    Caveats (over-count cases for ``has_open``/``correct``; both target zero-shot,
+    single-turn, special-token thinking evals):
+    - Few-shot: demonstration think tags in the prompt make ``has_open`` ~1.
+    - Multi-turn: a prior turn's *unclosed* open survives in the rendered history
+      (context), so a later turn that emits only a stray close can read
+      ``correct`` = 1. The signal is per-turn well-formedness modulo prior-turn
+      leakage, not a strict per-turn balance check.
+    """
+    info: dict = {}
+    with contextlib.suppress(Exception):
+        context = context or ""
+        # The close must be emitted by the model -> search the generation only.
+        gen_close = generation.find(think_end_token) if think_end_token else -1
+        if think_end_token:
+            info["thinking_format_has_close"] = int(gen_close != -1)
+        if think_start_token:
+            # The open may be prefilled into the prompt, so accept it in either the
+            # prompt or the generation (no need to allocate context+generation).
+            open_in_context = think_start_token in context
+            gen_open = generation.find(think_start_token)
+            has_open = open_in_context or gen_open != -1
+            info["thinking_format_has_open"] = int(has_open)
+            if think_end_token:
+                has_close = gen_close != -1
+                # open precedes close: a prefilled open is before the generation;
+                # otherwise the open must occur in the generation before the close.
+                open_before_close = open_in_context or (0 <= gen_open < gen_close)
+                # a second open after the close => malformed (re-opened, unbalanced)
+                reopened = has_close and (
+                    generation.find(think_start_token, gen_close + len(think_end_token))
+                    != -1
+                )
+                info["thinking_format_correct"] = int(
+                    has_open and has_close and open_before_close and not reopened
+                )
+    return info
+
+
+def _detect_template_token(chat_template: str | None, var_name: str) -> str | None:
+    """Extract the value of a Jinja ``<var_name> = '...'`` assignment from a chat
+    template (last assignment wins), or None.
+    """
+    if not chat_template:
+        return None
+    matches = re.findall(rf"""\b{var_name}\s*=\s*['"]([^'"]+)['"]""", chat_template)
+    return matches[-1] if matches else None
+
+
+def template_declares_reasoning(chat_template: str | None) -> bool:
+    """Whether a chat template declares reasoning open/close tokens
+    (``inner_token`` / ``outer_token``), i.e. the model is thinking-capable.
+
+    NOTE: this matches the *presence* of an assignment (including unquoted /
+    variable values) and is INTENTIONALLY broader than ``detect_think_*_token``
+    (which only extracts quoted literals). The gap is load-bearing: it lets
+    :func:`resolve_think_tokens` fail loud when a template clearly declares
+    reasoning but the token value is not a parseable literal. Do not "dedupe" this
+    by reusing ``detect_think_*_token`` — that would silence the fail-loud guard.
+    """
+    if not chat_template:
+        return False
+    return re.search(r"\b(?:inner|outer)_token\s*=", chat_template) is not None
+
+
+def detect_think_start_token(chat_template: str | None) -> str | None:
+    """Derive the reasoning *open* token from a chat template's ``inner_token``
+    declaration (e.g. ``<think>`` / ``<|inner_prefix|>``), or None. See
+    :func:`detect_think_end_token` for the close counterpart.
+    """
+    return _detect_template_token(chat_template, "inner_token")
+
+
+def resolve_think_tokens(
+    chat_template: str | None,
+    enable_thinking: bool | None,
+    think_start_token: str | None,
+    think_end_token: str | None,
+) -> tuple[str | None, str | None]:
+    """Resolve the reasoning (open, close) string tokens, auto-detecting from the
+    chat template only where the caller didn't force a value.
+
+    Fail loud (req): the CLOSE token is essential (it drives the deliberation strip,
+    thinking-length, and the format metric), so when thinking is intended
+    (``enable_thinking``) and the template declares reasoning tokens but the close
+    cannot be resolved, raise — don't silently mis-handle the run. A missing OPEN
+    only affects the (non-fatal, suppressed) thinking-format metric, so it warns
+    once rather than aborting an otherwise-working strip/length run. For a
+    non-thinking model (template declares no reasoning tokens) this is a harmless
+    no-op returning ``(None, None)``.
+    """
+    start = (
+        think_start_token
+        if think_start_token is not None
+        else detect_think_start_token(chat_template)
+    )
+    end = (
+        think_end_token
+        if think_end_token is not None
+        else detect_think_end_token(chat_template)
+    )
+    if enable_thinking and template_declares_reasoning(chat_template):
+        if end is None:
+            raise ValueError(
+                "Thinking is enabled and the chat template declares reasoning "
+                "tokens, but the reasoning close (think_end_token) could not be "
+                "auto-detected from the template. Pass think_end_token= explicitly "
+                "in --model_args (or, on hf/vllm, set enable_thinking=False)."
+            )
+        if start is None:
+            warning_once(
+                eval_logger,
+                "Thinking is enabled but the reasoning open token could not be "
+                "auto-detected from the chat template; the thinking-format "
+                "open/correct metrics will not be tracked. Pass think_start_token= "
+                "in --model_args to enable them.",
+            )
+    return start, end
+
+
 def detect_think_end_token(chat_template: str | None) -> str | None:
     """Derive the reasoning *close* token (``think_end_token``) from a chat template.
 
@@ -1209,10 +1355,7 @@ def detect_think_end_token(chat_template: str | None) -> str | None:
     no auto-strip (and for a non-thinking run the token simply never appears, so the
     strip is a harmless no-op).
     """
-    if not chat_template:
-        return None
-    matches = re.findall(r"""outer_token\s*=\s*['"]([^'"]+)['"]""", chat_template)
-    return matches[-1] if matches else None
+    return _detect_template_token(chat_template, "outer_token")
 
 
 def has_bos_prefix(sequence: str, bos_str: str | Iterable[str] | None = None) -> bool:

--- a/lm_eval/models/utils.py
+++ b/lm_eval/models/utils.py
@@ -1158,9 +1158,10 @@ def postprocess_generated_text(
 
 def compute_generation_length_info(
     raw_text: str,
-    token_ids: list | None = None,
+    token_ids: Sequence | None = None,
     think_end_token: str | None = None,
-    tokenizer=None,
+    tokenizer: Any = None,
+    measure_thinking: bool = True,
 ) -> dict:
     """Length of a raw generation (and its thinking span) for per-sample logging.
 
@@ -1168,23 +1169,26 @@ def compute_generation_length_info(
     thinking span — so response/thinking length survive thinking-mode scoring (which
     keeps only the text after ``think_end_token``). The response covers the full
     generation (reasoning + answer); the thinking span is everything up to and
-    including ``think_end_token`` (the model emits reasoning first).
+    including the LAST ``think_end_token`` — the same boundary the strip uses (which
+    keeps only the text after the last close).
 
     Always returns ``response_length_{words,chars}`` (plus ``_tokens`` from the exact
-    generated ``token_ids`` when available); adds ``thinking_length_{words,chars}``
+    generated ``token_ids`` when available). Adds ``thinking_length_{words,chars}``
     (plus ``_tokens`` by re-encoding the span when a ``tokenizer`` is given) only when
-    the text contains a ``think_end_token``. Never raises — length logging must not
-    break generation.
+    ``measure_thinking`` is True AND the text contains a ``think_end_token``. Callers
+    pass ``measure_thinking`` only for well-formed responses, so the thinking span is
+    never mis-attributed (e.g. a turn that closes a block opened in a prior turn).
+    Never raises — length logging must not break generation.
     """
     info: dict = {}
-    # never let length logging break generation
     with contextlib.suppress(Exception):
         info["response_length_words"] = len(raw_text.split())
         info["response_length_chars"] = len(raw_text)
         if token_ids is not None:
             info["response_length_tokens"] = len(token_ids)
-        if think_end_token and think_end_token in raw_text:
-            thinking_text = raw_text.split(think_end_token, 1)[0] + think_end_token
+        if measure_thinking and think_end_token and think_end_token in raw_text:
+            # up to and including the LAST close, matching the strip
+            thinking_text = raw_text.rsplit(think_end_token, 1)[0] + think_end_token
             info["thinking_length_words"] = len(thinking_text.split())
             info["thinking_length_chars"] = len(thinking_text)
             if tokenizer is not None:
@@ -1196,68 +1200,116 @@ def compute_generation_length_info(
     return info
 
 
+def attach_length_info(requests, length_res) -> None:
+    """Attach each per-response generation-info dict back onto its originating
+    Instance (one entry per response, mirroring how ``resps`` are appended).
+    ``length_res`` must already be in the original request order.
+    """
+    for req, info in zip(requests, length_res, strict=True):
+        req.length_info.append(info)
+
+
 def compute_thinking_format_info(
     generation: str,
-    context: str | None = None,
     think_start_token: str | None = None,
     think_end_token: str | None = None,
+    open_prefilled: bool = False,
 ) -> dict:
     """Whether a generation's reasoning (think) block is well-formed.
 
-    Returns 0/1 flags for per-sample logging (aggregated to a per-task rate):
+    Returns 0/1 flags for per-sample logging (aggregated to a per-task rate). All
+    checks look at the **current turn only** — never the prompt/history — so a prior
+    turn's leaked open cannot inflate the signal (multi-turn correctness):
 
-    - ``thinking_format_has_open``  — the open token is present in the prompt OR the
-      generation. Thinking templates usually *prefill* the open token into the
-      prompt (so the model emits only the close), hence the open is searched across
-      ``context + generation``; a model that emits its own open is covered too.
-      (For prefill templates this is ~always 1 — it still flags the case where the
-      block was never opened, e.g. a non-thinking path.)
+    - ``thinking_format_has_open``  — the open token was opened *this turn*: emitted in
+      the generation, OR injected by the template's generation prompt (``open_prefilled``;
+      a per-model fact, not the rendered history). Only emitted when an open token is
+      known.
     - ``thinking_format_has_close`` — the close token is present in the generation
       (the model must actually emit it).
-    - ``thinking_format_correct``   — open present, close present, open precedes the
-      close, AND the block is not re-opened after the close (catches a stray second
-      open such as ``</think>...<think>...`` that would otherwise pass a bare
-      open<close ordering check when the open is prefilled).
+    - ``thinking_format_correct``:
+        * open+close model — open present (this turn), close present, open precedes the
+          (last) close, AND the block is not re-opened after the (first) close (catches
+          a stray second open such as ``</think>...<think>...``). The close boundary is
+          the LAST close, matching the strip; re-open is probed from the FIRST close.
+        * close-only model (no open token known) — reduces to ``has_close`` (the only
+          available notion of well-formedness is "did it close").
 
-    A flag is only emitted when its token is known, mirroring how
-    ``thinking_length_*`` is gated. Never raises — format logging must not break
-    generation.
-
-    Caveats (over-count cases for ``has_open``/``correct``; both target zero-shot,
-    single-turn, special-token thinking evals):
-    - Few-shot: demonstration think tags in the prompt make ``has_open`` ~1.
-    - Multi-turn: a prior turn's *unclosed* open survives in the rendered history
-      (context), so a later turn that emits only a stray close can read
-      ``correct`` = 1. The signal is per-turn well-formedness modulo prior-turn
-      leakage, not a strict per-turn balance check.
+    ``correct`` is emitted whenever the **close** token is known (open+close OR
+    close-only). Never raises — format logging must not break generation.
     """
     info: dict = {}
     with contextlib.suppress(Exception):
-        context = context or ""
-        # The close must be emitted by the model -> search the generation only.
-        gen_close = generation.find(think_end_token) if think_end_token else -1
+        # The close must be emitted by the model -> search the generation only. Use the
+        # LAST close as the boundary, matching the strip (which keeps text after it).
+        gen_close = generation.rfind(think_end_token) if think_end_token else -1
+        has_close = gen_close != -1
         if think_end_token:
-            info["thinking_format_has_close"] = int(gen_close != -1)
+            info["thinking_format_has_close"] = int(has_close)
         if think_start_token:
-            # The open may be prefilled into the prompt, so accept it in either the
-            # prompt or the generation (no need to allocate context+generation).
-            open_in_context = think_start_token in context
+            # "Opened this turn" = the model emitted the open, or the template prefilled
+            # it into the generation prompt. The rendered history is NOT consulted.
             gen_open = generation.find(think_start_token)
-            has_open = open_in_context or gen_open != -1
+            has_open = open_prefilled or gen_open != -1
             info["thinking_format_has_open"] = int(has_open)
             if think_end_token:
-                has_close = gen_close != -1
                 # open precedes close: a prefilled open is before the generation;
                 # otherwise the open must occur in the generation before the close.
-                open_before_close = open_in_context or (0 <= gen_open < gen_close)
-                # a second open after the close => malformed (re-opened, unbalanced)
+                open_before_close = open_prefilled or (0 <= gen_open < gen_close)
+                # Re-opened after closing => malformed. Probe from the FIRST close so an
+                # open sitting between two closes is still caught.
+                first_close = generation.find(think_end_token)
                 reopened = has_close and (
-                    generation.find(think_start_token, gen_close + len(think_end_token))
+                    generation.find(
+                        think_start_token, first_close + len(think_end_token)
+                    )
                     != -1
                 )
                 info["thinking_format_correct"] = int(
                     has_open and has_close and open_before_close and not reopened
                 )
+        elif think_end_token:
+            # Close-only model: well-formedness reduces to "did it close".
+            info["thinking_format_correct"] = int(has_close)
+    return info
+
+
+def build_length_info(
+    generation: str,
+    *,
+    token_ids: Sequence | None = None,
+    think_start_token: str | None = None,
+    think_end_token: str | None = None,
+    tokenizer: Any = None,
+    open_prefilled: bool = False,
+    track_thinking_metrics: bool = False,
+) -> dict:
+    """Per-response length+format dict for the **string-close** generation paths.
+
+    Computes the thinking-format flags first (current turn only), then the length —
+    passing ``measure_thinking`` so the thinking span is recorded ONLY for well-formed
+    responses (``thinking_format_correct == 1``). Shared by ``vllm``/``sglang`` and the
+    ``hf`` string-close path; the ``hf`` int-token path builds this inline because its
+    close boundary is a token id, not a string.
+    """
+    fmt = (
+        compute_thinking_format_info(
+            generation,
+            think_start_token=think_start_token,
+            think_end_token=think_end_token,
+            open_prefilled=open_prefilled,
+        )
+        if track_thinking_metrics
+        else {}
+    )
+    info = compute_generation_length_info(
+        generation,
+        token_ids=token_ids,
+        think_end_token=think_end_token,
+        tokenizer=tokenizer,
+        measure_thinking=bool(fmt.get("thinking_format_correct", 0)),
+    )
+    info.update(fmt)
     return info
 
 
@@ -1293,6 +1345,14 @@ def detect_think_start_token(chat_template: str | None) -> str | None:
     :func:`detect_think_end_token` for the close counterpart.
     """
     return _detect_template_token(chat_template, "inner_token")
+
+
+def detect_think_end_token(chat_template: str | None) -> str | None:
+    """Derive the reasoning *close* token from a chat template's ``outer_token``
+    declaration (e.g. ``</think>`` / ``<|inner_suffix|>``), or None. The close drives
+    the strip; :func:`resolve_think_tokens` owns the default/fail-loud behaviour.
+    """
+    return _detect_template_token(chat_template, "outer_token")
 
 
 def resolve_think_tokens(
@@ -1336,26 +1396,34 @@ def resolve_think_tokens(
                 eval_logger,
                 "Thinking is enabled but the reasoning open token could not be "
                 "auto-detected from the chat template; the thinking-format "
-                "open/correct metrics will not be tracked. Pass think_start_token= "
-                "in --model_args to enable them.",
+                "has_open metric will not be tracked (correct falls back to "
+                "has_close, close-only style). Pass think_start_token= in "
+                "--model_args to track it.",
             )
     return start, end
 
 
-def detect_think_end_token(chat_template: str | None) -> str | None:
-    """Derive the reasoning *close* token (``think_end_token``) from a chat template.
+def detect_open_prefilled(render_fn, think_start_token: str | None) -> bool:
+    """Whether the chat template injects the reasoning *open* token into the assistant
+    generation prompt (a "prefill" template), as opposed to the model emitting its own
+    open.
 
-    Apertus-style templates declare the reasoning open/close as ``inner_token`` /
-    ``outer_token`` (e.g. ``<think>``/``</think>``, or ``<|inner_prefix|>``/
-    ``<|inner_suffix|>`` on some checkpoints). Returns the close token when the
-    template declares one (last assignment wins), else None. Used by the causal LMs
-    to default ``think_end_token`` when the caller didn't set it explicitly, so the
-    deliberation span is stripped before scoring without the caller having to know
-    the model-specific token. Templates that declare no reasoning tokens -> None ->
-    no auto-strip (and for a non-thinking run the token simply never appears, so the
-    strip is a harmless no-op).
+    Probed once at init by rendering a trivial user-only chat *with* the generation
+    prompt via the backend's own ``apply_chat_template`` (so ``chat_template_args`` /
+    ``enable_thinking`` apply) and checking whether the open token appears — the demo
+    content carries no open token, so any occurrence comes from the template scaffold.
+    Feeds ``compute_thinking_format_info(open_prefilled=...)`` so ``has_open`` reflects
+    "opened this turn" for both prefill and non-prefill models. Never raises (returns
+    ``False`` on any failure, incl. no chat template / no open token).
     """
-    return _detect_template_token(chat_template, "outer_token")
+    if not think_start_token:
+        return False
+    with contextlib.suppress(Exception):
+        rendered = render_fn(
+            [{"role": "user", "content": "x"}], add_generation_prompt=True
+        )
+        return think_start_token in rendered
+    return False
 
 
 def has_bos_prefix(sequence: str, bos_str: str | Iterable[str] | None = None) -> bool:

--- a/lm_eval/models/utils.py
+++ b/lm_eval/models/utils.py
@@ -1127,6 +1127,27 @@ def maybe_truncate(
     return truncate_tokens(tokens, max_ctx_len, side=side), min_gen_toks
 
 
+def truncate_before_stops(generation: str, stop: list[str] | str | None) -> str:
+    """Return ``generation`` truncated before the earliest stop sequence.
+
+    The stop-truncation half of :func:`postprocess_generated_text`, split out so callers
+    can reproduce the scoring boundary without the thinking strip. HF uses it to bound
+    per-response measurement to a sequence's own response, dropping the over-generation
+    that whole-batch stopping leaves past the first stop.
+    """
+    if stop:
+        stop = [stop] if isinstance(stop, str) else stop
+        for term in stop:
+            if len(term) > 0:
+                # ignore '' separator,
+                # for seq2seq case where self.tok_decode(self.eot_token_id) = ''
+                # `partition` stops at the FIRST match; `split` would materialise every
+                # segment, which is costly on looping/degenerate output where a short
+                # stop recurs thousands of times.
+                generation = generation.partition(term)[0]
+    return generation
+
+
 def postprocess_generated_text(
     generation: str, stop: list[str] | str | None, think_end_token: str | None
 ) -> str:
@@ -1135,7 +1156,7 @@ def postprocess_generated_text(
 
     Args:
         generation (str): The generated text to be processed.
-        stop (list[str] | None): Stop sequence(s) to remove. Text is truncated
+        stop (list[str] | str | None): Stop sequence(s) to remove. Text is truncated
             at the first occurrence of any stop sequence.
         think_end_token (str | None): Token marking end of thinking section. If provided,
             returns only the text after this token (discarding thinking content).
@@ -1143,13 +1164,7 @@ def postprocess_generated_text(
     Returns:
         str: The processed generation - text before stop sequences and after thinking sections.
     """
-    if stop:
-        stop = [stop] if isinstance(stop, str) else stop
-        for term in stop:
-            if len(term) > 0:
-                # ignore '' separator,
-                # for seq2seq case where self.tok_decode(self.eot_token_id) = ''
-                generation = generation.split(term)[0]
+    generation = truncate_before_stops(generation, stop)
     if think_end_token:
         generation = generation.split(think_end_token)[-1].lstrip()
 
@@ -1163,22 +1178,21 @@ def compute_generation_length_info(
     tokenizer: Any = None,
     measure_thinking: bool = True,
 ) -> dict:
-    """Length of a raw generation (and its thinking span) for per-sample logging.
+    """Length of a generation, and of its thinking span, for per-sample logging.
 
-    Computed on the RAW generation, BEFORE ``postprocess_generated_text`` discards the
-    thinking span — so response/thinking length survive thinking-mode scoring (which
-    keeps only the text after ``think_end_token``). The response covers the full
-    generation (reasoning + answer); the thinking span is everything up to and
-    including the LAST ``think_end_token`` — the same boundary the strip uses (which
-    keeps only the text after the last close).
+    Measured before ``postprocess_generated_text`` strips the reasoning, so both survive
+    thinking-mode scoring. The response covers the whole generation (reasoning + answer);
+    the thinking span ends at the LAST ``think_end_token`` — the boundary the strip uses.
 
-    Always returns ``response_length_{words,chars}`` (plus ``_tokens`` from the exact
-    generated ``token_ids`` when available). Adds ``thinking_length_{words,chars}``
-    (plus ``_tokens`` by re-encoding the span when a ``tokenizer`` is given) only when
-    ``measure_thinking`` is True AND the text contains a ``think_end_token``. Callers
-    pass ``measure_thinking`` only for well-formed responses, so the thinking span is
-    never mis-attributed (e.g. a turn that closes a block opened in a prior turn).
-    Never raises — length logging must not break generation.
+    Always emits ``response_length_{words,chars}``, plus ``_tokens`` = ``len(token_ids)``
+    when given. Emits ``thinking_length_{words,chars}`` — plus ``_tokens``, a best-effort
+    re-encode, when ``tokenizer`` is given — only if ``measure_thinking`` and the text
+    contains a close. Callers set ``measure_thinking`` only for well-formed responses, so
+    the span is never mis-attributed (e.g. a turn closing a block opened in a prior turn).
+
+    ``raw_text``/``token_ids`` are the caller's view: vllm/sglang pass the engine's
+    per-response text and exact ids; hf passes a view bounded to the response (pad/eos
+    tail and post-stop over-generation removed). Never raises.
     """
     info: dict = {}
     with contextlib.suppress(Exception):
@@ -1217,26 +1231,21 @@ def compute_thinking_format_info(
 ) -> dict:
     """Whether a generation's reasoning (think) block is well-formed.
 
-    Returns 0/1 flags for per-sample logging (aggregated to a per-task rate). All
-    checks look at the **current turn only** — never the prompt/history — so a prior
-    turn's leaked open cannot inflate the signal (multi-turn correctness):
+    Returns 0/1 flags for per-sample logging (aggregated to a per-task rate). Every check
+    reads the **current turn only**, never the prompt/history, so a prior turn's leaked
+    open cannot inflate the signal:
 
-    - ``thinking_format_has_open``  — the open token was opened *this turn*: emitted in
-      the generation, OR injected by the template's generation prompt (``open_prefilled``;
-      a per-model fact, not the rendered history). Only emitted when an open token is
-      known.
-    - ``thinking_format_has_close`` — the close token is present in the generation
-      (the model must actually emit it).
-    - ``thinking_format_correct``:
-        * open+close model — open present (this turn), close present, open precedes the
-          (last) close, AND the block is not re-opened after the (first) close (catches
-          a stray second open such as ``</think>...<think>...``). The close boundary is
-          the LAST close, matching the strip; re-open is probed from the FIRST close.
-        * close-only model (no open token known) — reduces to ``has_close`` (the only
-          available notion of well-formedness is "did it close").
+    - ``has_open`` — opened this turn: emitted in the generation, or injected by the
+      template's generation prompt (``open_prefilled``, a per-model fact). Only emitted
+      when an open token is known.
+    - ``has_close`` — the model emitted the close token.
+    - ``correct`` — open+close model: open and close present, open precedes the LAST
+      close (the strip's boundary), and no re-open after the FIRST close (catches a stray
+      second open, ``</think>...<think>...``). Close-only model (no open token known): it
+      reduces to ``has_close``.
 
-    ``correct`` is emitted whenever the **close** token is known (open+close OR
-    close-only). Never raises — format logging must not break generation.
+    All keys are prefixed ``thinking_format_``. ``correct`` is emitted whenever the close
+    is known. Never raises.
     """
     info: dict = {}
     with contextlib.suppress(Exception):
@@ -1286,11 +1295,10 @@ def build_length_info(
 ) -> dict:
     """Per-response length+format dict for the **string-close** generation paths.
 
-    Computes the thinking-format flags first (current turn only), then the length —
-    passing ``measure_thinking`` so the thinking span is recorded ONLY for well-formed
-    responses (``thinking_format_correct == 1``). Shared by ``vllm``/``sglang`` and the
-    ``hf`` string-close path; the ``hf`` int-token path builds this inline because its
-    close boundary is a token id, not a string.
+    Format-first: the thinking span is measured only for well-formed responses
+    (``thinking_format_correct == 1``). Shared by ``vllm``/``sglang`` and the ``hf``
+    string-close path; the ``hf`` int-token path builds the same dict inline because its
+    close boundary is a token id, not a string — keep the two in sync.
     """
     fmt = (
         compute_thinking_format_info(
@@ -1324,15 +1332,14 @@ def _detect_template_token(chat_template: str | None, var_name: str) -> str | No
 
 
 def template_declares_reasoning(chat_template: str | None) -> bool:
-    """Whether a chat template declares reasoning open/close tokens
-    (``inner_token`` / ``outer_token``), i.e. the model is thinking-capable.
+    """Whether a chat template declares reasoning tokens (``inner_token`` /
+    ``outer_token``), i.e. the model is thinking-capable.
 
-    NOTE: this matches the *presence* of an assignment (including unquoted /
-    variable values) and is INTENTIONALLY broader than ``detect_think_*_token``
-    (which only extracts quoted literals). The gap is load-bearing: it lets
-    :func:`resolve_think_tokens` fail loud when a template clearly declares
-    reasoning but the token value is not a parseable literal. Do not "dedupe" this
-    by reusing ``detect_think_*_token`` — that would silence the fail-loud guard.
+    Matches an assignment's *presence* (even an unquoted/variable value), so it is
+    deliberately broader than ``detect_think_*_token``, which extracts only quoted
+    literals. That gap is load-bearing: it lets :func:`resolve_think_tokens` fail loud on
+    a template that declares reasoning but whose token value isn't a parseable literal.
+    Do not "dedupe" the two — it would silence the guard.
     """
     if not chat_template:
         return False
@@ -1357,64 +1364,108 @@ def detect_think_end_token(chat_template: str | None) -> str | None:
 
 def resolve_think_tokens(
     chat_template: str | None,
-    enable_thinking: bool | None,
+    autodetect: bool | None,
     think_start_token: str | None,
     think_end_token: str | None,
 ) -> tuple[str | None, str | None]:
-    """Resolve the reasoning (open, close) string tokens, auto-detecting from the
-    chat template only where the caller didn't force a value.
+    """Resolve the reasoning (open, close) string tokens.
 
-    Fail loud (req): the CLOSE token is essential (it drives the deliberation strip,
-    thinking-length, and the format metric), so when thinking is intended
-    (``enable_thinking``) and the template declares reasoning tokens but the close
-    cannot be resolved, raise — don't silently mis-handle the run. A missing OPEN
-    only affects the (non-fatal, suppressed) thinking-format metric, so it warns
-    once rather than aborting an otherwise-working strip/length run. For a
-    non-thinking model (template declares no reasoning tokens) this is a harmless
+    Caller-forced values always win. Auto-detection from the chat template is gated on
+    ``autodetect``, which is **opt-in** (``autodetect_think_tokens``, default off): when it
+    is falsy the template is not consulted at all, so an unconfigured run resolves no
+    close and therefore gets no strip and no thinking metrics. ``enable_thinking`` plays
+    no part — it is a chat-template argument only.
+
+    The CLOSE is load-bearing: it drives the strip, the thinking span and ``has_close``.
+    Fail loud when auto-detection is on and the template declares reasoning tokens but the
+    close cannot be parsed as a literal — pass ``think_end_token=`` instead, or drop
+    ``autodetect_think_tokens=true``. With detection off (the default) it never fires.
+
+    A missing OPEN is non-fatal: it only costs ``has_open``, and ``correct`` degrades to
+    ``has_close`` (close-only style), so it warns. An open *without* a close warns too —
+    nothing can be stripped or measured. A template declaring no reasoning tokens is a
     no-op returning ``(None, None)``.
     """
-    start = (
-        think_start_token
-        if think_start_token is not None
-        else detect_think_start_token(chat_template)
-    )
-    end = (
-        think_end_token
-        if think_end_token is not None
-        else detect_think_end_token(chat_template)
-    )
-    if enable_thinking and template_declares_reasoning(chat_template):
-        if end is None:
-            raise ValueError(
-                "Thinking is enabled and the chat template declares reasoning "
-                "tokens, but the reasoning close (think_end_token) could not be "
-                "auto-detected from the template. Pass think_end_token= explicitly "
-                "in --model_args (or, on hf/vllm, set enable_thinking=False)."
-            )
+    # Caller-forced values always win; consult the template only when autodetect is on.
+    start = think_start_token
+    end = think_end_token
+    if autodetect:
         if start is None:
-            warning_once(
-                eval_logger,
-                "Thinking is enabled but the reasoning open token could not be "
-                "auto-detected from the chat template; the thinking-format "
-                "has_open metric will not be tracked (correct falls back to "
-                "has_close, close-only style). Pass think_start_token= in "
-                "--model_args to track it.",
-            )
+            start = detect_think_start_token(chat_template)
+        if end is None:
+            end = detect_think_end_token(chat_template)
+        if template_declares_reasoning(chat_template):
+            if end is None:
+                raise ValueError(
+                    "Reasoning-token auto-detection is on "
+                    "(autodetect_think_tokens=true) and the chat template declares "
+                    "reasoning tokens, but the reasoning close (think_end_token) could "
+                    "not be auto-detected from the template. Pass think_end_token= "
+                    "explicitly in --model_args, or turn detection off "
+                    "(autodetect_think_tokens=false, the default)."
+                )
+            if start is None:
+                warning_once(
+                    eval_logger,
+                    "The reasoning open token could not be auto-detected from the chat "
+                    "template; the thinking-format has_open metric will not be tracked "
+                    "(correct falls back to has_close, close-only style). Pass "
+                    "think_start_token= in --model_args to track it.",
+                )
+    if start is not None and end is None:
+        # An open alone is useless: the strip and every thinking metric key off the close.
+        warning_once(
+            eval_logger,
+            "A reasoning open token is known but no close token is; the reasoning strip "
+            "and the thinking-format/length metrics stay off (has_close and the thinking "
+            "span are undefined without a close). Pass think_end_token= in --model_args.",
+        )
     return start, end
 
 
-def detect_open_prefilled(render_fn, think_start_token: str | None) -> bool:
-    """Whether the chat template injects the reasoning *open* token into the assistant
-    generation prompt (a "prefill" template), as opposed to the model emitting its own
-    open.
+def resolve_track_thinking_metrics(
+    override: bool | None,
+    think_end_token: str | int | None,
+) -> bool:
+    """Whether to record the ``thinking_format_*`` / ``thinking_length_*`` metrics.
 
-    Probed once at init by rendering a trivial user-only chat *with* the generation
-    prompt via the backend's own ``apply_chat_template`` (so ``chat_template_args`` /
-    ``enable_thinking`` apply) and checking whether the open token appears — the demo
-    content carries no open token, so any occurrence comes from the template scaffold.
-    Feeds ``compute_thinking_format_info(open_prefilled=...)`` so ``has_open`` reflects
-    "opened this turn" for both prefill and non-prefill models. Never raises (returns
-    ``False`` on any failure, incl. no chat template / no open token).
+    Derived from the CLOSE token alone: with ``override=None`` (default) track iff a close
+    is known, whether explicitly passed or auto-detected. ``True``/``False`` force it on or
+    off — e.g. off to drop the metrics (and their per-response cost) from a thinking run.
+
+    The close may be a string or (on ``hf``) an integer token id. "Known" means *not None*
+    and not the empty string — never a plain truthiness test, since ``0`` is a valid token
+    id whose falsiness would otherwise silently disable tracking.
+
+    The close is required either way: it defines ``has_close`` and the thinking span, so
+    forcing ``True`` without one warns and returns False. A missing OPEN is fine — the
+    format metric degrades to close-only (``correct == has_close``). ``response_length_*``
+    is unaffected; it is always recorded. ``enable_thinking`` plays no part here: it is a
+    chat-template argument only.
+    """
+    if think_end_token is None or think_end_token == "":
+        if override:
+            warning_once(
+                eval_logger,
+                "track_thinking_metrics=True but no reasoning close token is known; "
+                "thinking metrics stay off. Pass think_end_token= in --model_args.",
+            )
+        return False
+    if override is not None:
+        return bool(override)
+    return True
+
+
+def detect_open_prefilled(render_fn, think_start_token: str | None) -> bool:
+    """Whether the chat template injects the reasoning *open* into the generation prompt
+    (a "prefill" template) rather than the model emitting its own.
+
+    Probed once at init by rendering a trivial user-only chat through the backend's own
+    ``apply_chat_template`` (so ``chat_template_args``/``enable_thinking`` apply): the
+    demo content has no open token, so any occurrence comes from the template scaffold.
+    Feeds ``compute_thinking_format_info(open_prefilled=...)`` so ``has_open`` means
+    "opened this turn" for prefill and non-prefill models alike. Never raises — returns
+    ``False`` on any failure (no chat template, no open token, render error).
     """
     if not think_start_token:
         return False

--- a/lm_eval/models/utils.py
+++ b/lm_eval/models/utils.py
@@ -1156,6 +1156,65 @@ def postprocess_generated_text(
     return generation
 
 
+def compute_generation_length_info(
+    raw_text: str,
+    token_ids: list | None = None,
+    think_end_token: str | None = None,
+    tokenizer=None,
+) -> dict:
+    """Length of a raw generation (and its thinking span) for per-sample logging.
+
+    Computed on the RAW generation, BEFORE ``postprocess_generated_text`` discards the
+    thinking span — so response/thinking length survive thinking-mode scoring (which
+    keeps only the text after ``think_end_token``). The response covers the full
+    generation (reasoning + answer); the thinking span is everything up to and
+    including ``think_end_token`` (the model emits reasoning first).
+
+    Always returns ``response_length_{words,chars}`` (plus ``_tokens`` from the exact
+    generated ``token_ids`` when available); adds ``thinking_length_{words,chars}``
+    (plus ``_tokens`` by re-encoding the span when a ``tokenizer`` is given) only when
+    the text contains a ``think_end_token``. Never raises — length logging must not
+    break generation.
+    """
+    info: dict = {}
+    # never let length logging break generation
+    with contextlib.suppress(Exception):
+        info["response_length_words"] = len(raw_text.split())
+        info["response_length_chars"] = len(raw_text)
+        if token_ids is not None:
+            info["response_length_tokens"] = len(token_ids)
+        if think_end_token and think_end_token in raw_text:
+            thinking_text = raw_text.split(think_end_token, 1)[0] + think_end_token
+            info["thinking_length_words"] = len(thinking_text.split())
+            info["thinking_length_chars"] = len(thinking_text)
+            if tokenizer is not None:
+                # token count is best-effort
+                with contextlib.suppress(Exception):
+                    info["thinking_length_tokens"] = len(
+                        tokenizer.encode(thinking_text, add_special_tokens=False)
+                    )
+    return info
+
+
+def detect_think_end_token(chat_template: str | None) -> str | None:
+    """Derive the reasoning *close* token (``think_end_token``) from a chat template.
+
+    Apertus-style templates declare the reasoning open/close as ``inner_token`` /
+    ``outer_token`` (e.g. ``<think>``/``</think>``, or ``<|inner_prefix|>``/
+    ``<|inner_suffix|>`` on some checkpoints). Returns the close token when the
+    template declares one (last assignment wins), else None. Used by the causal LMs
+    to default ``think_end_token`` when the caller didn't set it explicitly, so the
+    deliberation span is stripped before scoring without the caller having to know
+    the model-specific token. Templates that declare no reasoning tokens -> None ->
+    no auto-strip (and for a non-thinking run the token simply never appears, so the
+    strip is a harmless no-op).
+    """
+    if not chat_template:
+        return None
+    matches = re.findall(r"""outer_token\s*=\s*['"]([^'"]+)['"]""", chat_template)
+    return matches[-1] if matches else None
+
+
 def has_bos_prefix(sequence: str, bos_str: str | Iterable[str] | None = None) -> bool:
     if bos_str is None:
         return False

--- a/lm_eval/models/vllm_causallms.py
+++ b/lm_eval/models/vllm_causallms.py
@@ -24,10 +24,11 @@ from lm_eval.api.registry import register_model
 from lm_eval.models.utils import (
     Collator,
     _add_special_kwargs,
+    attach_length_info,
+    build_length_info,
     check_system_boilerplate,
-    compute_generation_length_info,
-    compute_thinking_format_info,
     configure_pad_token,
+    detect_open_prefilled,
     get_template_special_tokens,
     handle_stop_sequences,
     has_bos_prefix,
@@ -257,10 +258,8 @@ class VLLM(TemplateLM):
         self.enable_thinking = self.chat_template_args.pop(
             "enable_thinking", enable_thinking
         )
-        # Default the reasoning open/close tokens from the model's chat template when
-        # the caller didn't set them explicitly, so the deliberation span is stripped
-        # before scoring (and measured for length/format) without the caller knowing
-        # the tokens. Fails loud if thinking is on but tokens can't be resolved.
+        # Auto-detect the open/close tokens from the chat template when not forced.
+        # Fails loud if thinking is on but they can't be resolved.
         self.think_start_token, self.think_end_token = resolve_think_tokens(
             getattr(self.tokenizer, "chat_template", None),
             self.enable_thinking,
@@ -302,6 +301,15 @@ class VLLM(TemplateLM):
         # in chat_template_args would cause a duplicate-kwarg TypeError.
         if "chat_template" in self.chat_template_args:
             self.hf_chat_template = self.chat_template_args.pop("chat_template")
+
+        # Whether the template prefills the reasoning open into the generation prompt
+        # (vs the model emitting its own) — feeds the per-turn has_open check. Probed
+        # after hf_chat_template is set (apply_chat_template depends on it).
+        self.think_open_prefilled = detect_open_prefilled(
+            self.apply_chat_template, self.think_start_token
+        )
+        # Track thinking metrics only when thinking is on and a close token is known.
+        self.track_thinking_metrics = bool(self.enable_thinking and self.think_end_token)
 
         # System-prompt authority probe — OFF by default; opt in via
         # `check_system_prompt_authority` (and not waived by `allow_system_boilerplate`).
@@ -684,9 +692,8 @@ class VLLM(TemplateLM):
     ) -> list[str]:
         assert self.tokenizer
         res = []
-        # Parallel to `res`: per-response length info measured on the RAW generation
-        # (before postprocess_generated_text strips the thinking span). Carried back
-        # to the originating Instances at the end so the evaluator can log it.
+        # Parallel to `res`: per-response length info on the RAW generation (before
+        # the thinking span is stripped), carried back to the Instances at the end.
         length_res = []
 
         # batch tokenize contexts
@@ -764,26 +771,19 @@ class VLLM(TemplateLM):
             # cache generations
             for output, _context in zip(cont, context, strict=True):
                 generated_text: str = output.outputs[0].text
-                # Measure length on the RAW generation (before the thinking span is
-                # stripped below), so response/thinking length survive thinking mode.
-                # Response token count comes from the exact generated token_ids.
-                _info = compute_generation_length_info(
-                    generated_text,
-                    token_ids=getattr(output.outputs[0], "token_ids", None),
-                    think_end_token=self.think_end_token,
-                    tokenizer=self.tokenizer,
-                )
-                # Whether the reasoning block is well-formed (open in prompt+gen,
-                # close in gen). think_end_token is already a str|None here.
-                _info.update(
-                    compute_thinking_format_info(
+                # Per-response length + current-turn thinking-format (format-first, so
+                # the thinking span is measured only for well-formed responses).
+                length_res.append(
+                    build_length_info(
                         generated_text,
-                        context=_context,
+                        token_ids=getattr(output.outputs[0], "token_ids", None),
                         think_start_token=self.think_start_token,
                         think_end_token=self.think_end_token,
+                        tokenizer=self.tokenizer,
+                        open_prefilled=self.think_open_prefilled,
+                        track_thinking_metrics=self.track_thinking_metrics,
                     )
                 )
-                length_res.append(_info)
                 # use secondary stop seqs to cut off should-have-been-stopped content post-hoc
                 generated_text = postprocess_generated_text(
                     generated_text, until, self.think_end_token
@@ -797,12 +797,8 @@ class VLLM(TemplateLM):
         pbar.close()
         # reorder all group of results back to original unsorted form
         res = re_ords.get_original(res)
-        # Carry the parallel length info back to the originating Instances, in the
-        # same (restored) order as `res`. Appends one entry per response, mirroring
-        # how the evaluator appends `resps`; downstream logging reads req.length_info.
-        length_res = re_ords.get_original(length_res)
-        for req, info in zip(requests, length_res, strict=True):
-            req.length_info.append(info)
+        # Carry length info back to the Instances, in the same restored order as `res`.
+        attach_length_info(requests, re_ords.get_original(length_res))
         return res
 
     def _loglikelihood_tokens(

--- a/lm_eval/models/vllm_causallms.py
+++ b/lm_eval/models/vllm_causallms.py
@@ -25,7 +25,9 @@ from lm_eval.models.utils import (
     Collator,
     _add_special_kwargs,
     check_system_boilerplate,
+    compute_generation_length_info,
     configure_pad_token,
+    detect_think_end_token,
     get_template_special_tokens,
     handle_stop_sequences,
     has_bos_prefix,
@@ -250,6 +252,13 @@ class VLLM(TemplateLM):
         self.enable_thinking = self.chat_template_args.pop(
             "enable_thinking", enable_thinking
         )
+        # Default the reasoning-strip token from the model's chat template when the
+        # caller didn't set it explicitly, so the deliberation span is stripped before
+        # scoring (and measured for length) without the caller knowing the token.
+        if self.think_end_token is None:
+            self.think_end_token = detect_think_end_token(
+                getattr(self.tokenizer, "chat_template", None)
+            )
 
         if parse_version(version("vllm")) >= parse_version("0.8.3"):
             kwargs_resolve_hf_chat_template = {
@@ -667,6 +676,10 @@ class VLLM(TemplateLM):
     ) -> list[str]:
         assert self.tokenizer
         res = []
+        # Parallel to `res`: per-response length info measured on the RAW generation
+        # (before postprocess_generated_text strips the thinking span). Carried back
+        # to the originating Instances at the end so the evaluator can log it.
+        length_res = []
 
         # batch tokenize contexts
         context, all_gen_kwargs = zip(*(req.args for req in requests), strict=True)
@@ -743,6 +756,17 @@ class VLLM(TemplateLM):
             # cache generations
             for output, _context in zip(cont, context, strict=True):
                 generated_text: str = output.outputs[0].text
+                # Measure length on the RAW generation (before the thinking span is
+                # stripped below), so response/thinking length survive thinking mode.
+                # Response token count comes from the exact generated token_ids.
+                length_res.append(
+                    compute_generation_length_info(
+                        generated_text,
+                        token_ids=getattr(output.outputs[0], "token_ids", None),
+                        think_end_token=self.think_end_token,
+                        tokenizer=self.tokenizer,
+                    )
+                )
                 # use secondary stop seqs to cut off should-have-been-stopped content post-hoc
                 generated_text = postprocess_generated_text(
                     generated_text, until, self.think_end_token
@@ -755,7 +779,14 @@ class VLLM(TemplateLM):
 
         pbar.close()
         # reorder all group of results back to original unsorted form
-        return re_ords.get_original(res)
+        res = re_ords.get_original(res)
+        # Carry the parallel length info back to the originating Instances, in the
+        # same (restored) order as `res`. Appends one entry per response, mirroring
+        # how the evaluator appends `resps`; downstream logging reads req.length_info.
+        length_res = re_ords.get_original(length_res)
+        for req, info in zip(requests, length_res, strict=True):
+            req.length_info.append(info)
+        return res
 
     def _loglikelihood_tokens(
         self,

--- a/lm_eval/models/vllm_causallms.py
+++ b/lm_eval/models/vllm_causallms.py
@@ -26,8 +26,8 @@ from lm_eval.models.utils import (
     _add_special_kwargs,
     check_system_boilerplate,
     compute_generation_length_info,
+    compute_thinking_format_info,
     configure_pad_token,
-    detect_think_end_token,
     get_template_special_tokens,
     handle_stop_sequences,
     has_bos_prefix,
@@ -35,6 +35,7 @@ from lm_eval.models.utils import (
     maybe_truncate,
     normalize_gen_kwargs,
     postprocess_generated_text,
+    resolve_think_tokens,
     undistribute,
 )
 from lm_eval.utils import (
@@ -161,6 +162,9 @@ class VLLM(TemplateLM):
         check_system_prompt_authority: bool = False,
         # End marker for thinking tags - splits to get response after this token (if provided).
         think_end_token: str | None = None,
+        # Start marker for thinking tags - used for the thinking-format metric. Auto-
+        # detected from the chat template when not set.
+        think_start_token: str | None = None,
         max_lora_rank: int = 16,
         truncation_side: Literal["left", "right", "middle"] = "left",
         **kwargs,
@@ -178,6 +182,7 @@ class VLLM(TemplateLM):
         )
         kwargs.pop("device", None)
         self.think_end_token = think_end_token
+        self.think_start_token = think_start_token
         self.V1 = os.environ.get("VLLM_USE_V1", "1") != "0"
         self._max_length = max_model_len if max_model_len is not None else max_length
         self.tensor_parallel_size = int(tensor_parallel_size)
@@ -252,13 +257,16 @@ class VLLM(TemplateLM):
         self.enable_thinking = self.chat_template_args.pop(
             "enable_thinking", enable_thinking
         )
-        # Default the reasoning-strip token from the model's chat template when the
-        # caller didn't set it explicitly, so the deliberation span is stripped before
-        # scoring (and measured for length) without the caller knowing the token.
-        if self.think_end_token is None:
-            self.think_end_token = detect_think_end_token(
-                getattr(self.tokenizer, "chat_template", None)
-            )
+        # Default the reasoning open/close tokens from the model's chat template when
+        # the caller didn't set them explicitly, so the deliberation span is stripped
+        # before scoring (and measured for length/format) without the caller knowing
+        # the tokens. Fails loud if thinking is on but tokens can't be resolved.
+        self.think_start_token, self.think_end_token = resolve_think_tokens(
+            getattr(self.tokenizer, "chat_template", None),
+            self.enable_thinking,
+            self.think_start_token,
+            self.think_end_token,
+        )
 
         if parse_version(version("vllm")) >= parse_version("0.8.3"):
             kwargs_resolve_hf_chat_template = {
@@ -759,14 +767,23 @@ class VLLM(TemplateLM):
                 # Measure length on the RAW generation (before the thinking span is
                 # stripped below), so response/thinking length survive thinking mode.
                 # Response token count comes from the exact generated token_ids.
-                length_res.append(
-                    compute_generation_length_info(
+                _info = compute_generation_length_info(
+                    generated_text,
+                    token_ids=getattr(output.outputs[0], "token_ids", None),
+                    think_end_token=self.think_end_token,
+                    tokenizer=self.tokenizer,
+                )
+                # Whether the reasoning block is well-formed (open in prompt+gen,
+                # close in gen). think_end_token is already a str|None here.
+                _info.update(
+                    compute_thinking_format_info(
                         generated_text,
-                        token_ids=getattr(output.outputs[0], "token_ids", None),
+                        context=_context,
+                        think_start_token=self.think_start_token,
                         think_end_token=self.think_end_token,
-                        tokenizer=self.tokenizer,
                     )
                 )
+                length_res.append(_info)
                 # use secondary stop seqs to cut off should-have-been-stopped content post-hoc
                 generated_text = postprocess_generated_text(
                     generated_text, until, self.think_end_token

--- a/lm_eval/models/vllm_causallms.py
+++ b/lm_eval/models/vllm_causallms.py
@@ -37,6 +37,7 @@ from lm_eval.models.utils import (
     normalize_gen_kwargs,
     postprocess_generated_text,
     resolve_think_tokens,
+    resolve_track_thinking_metrics,
     undistribute,
 )
 from lm_eval.utils import (
@@ -155,7 +156,8 @@ class VLLM(TemplateLM):
         gpu_memory_utilization: float = 0.9,
         data_parallel_size: int = 1,
         lora_local_path: str | None = None,
-        # VLLM: enable thinking tags in the prompt.
+        # VLLM: enable thinking tags in the prompt. Chat-template argument only; it does
+        # not affect the strip, token auto-detection or the thinking metrics.
         enable_thinking: bool = True,
         chat_template_args: dict | None = None,
         strip_system_boilerplate: bool = False,
@@ -164,8 +166,16 @@ class VLLM(TemplateLM):
         # End marker for thinking tags - splits to get response after this token (if provided).
         think_end_token: str | None = None,
         # Start marker for thinking tags - used for the thinking-format metric. Auto-
-        # detected from the chat template when not set.
+        # detected from the chat template only with `autodetect_think_tokens`.
         think_start_token: str | None = None,
+        # opt in to auto-detecting the reasoning tokens from the chat template. Off (the
+        # default) => the template is never scanned, so without an explicit
+        # think_end_token there is no strip and no thinking metrics. Must be a named
+        # parameter: `**kwargs` is merged into `model_args` and forwarded to `LLM(...)`.
+        autodetect_think_tokens: bool = False,
+        # force the thinking-format/length metrics on/off; None = derive from whether a
+        # reasoning close token is known.
+        track_thinking_metrics: bool | None = None,
         max_lora_rank: int = 16,
         truncation_side: Literal["left", "right", "middle"] = "left",
         **kwargs,
@@ -258,11 +268,13 @@ class VLLM(TemplateLM):
         self.enable_thinking = self.chat_template_args.pop(
             "enable_thinking", enable_thinking
         )
-        # Auto-detect the open/close tokens from the chat template when not forced.
-        # Fails loud if thinking is on but they can't be resolved.
+        # Auto-detect the open/close tokens from the chat template when not forced (and
+        # only when `autodetect_think_tokens`). Fails loud if the template declares
+        # reasoning tokens but the close can't be resolved. The strip then runs iff a
+        # close is known. `self.enable_thinking` is used solely for template rendering.
         self.think_start_token, self.think_end_token = resolve_think_tokens(
             getattr(self.tokenizer, "chat_template", None),
-            self.enable_thinking,
+            autodetect_think_tokens,
             self.think_start_token,
             self.think_end_token,
         )
@@ -308,8 +320,11 @@ class VLLM(TemplateLM):
         self.think_open_prefilled = detect_open_prefilled(
             self.apply_chat_template, self.think_start_token
         )
-        # Track thinking metrics only when thinking is on and a close token is known.
-        self.track_thinking_metrics = bool(self.enable_thinking and self.think_end_token)
+        # Derived from a known close, unless forced by the caller. A missing open is fine
+        # and degrades the format metric to close-only.
+        self.track_thinking_metrics = resolve_track_thinking_metrics(
+            track_thinking_metrics, self.think_end_token
+        )
 
         # System-prompt authority probe — OFF by default; opt in via
         # `check_system_prompt_authority` (and not waived by `allow_system_boilerplate`).

--- a/tests/models/test_huggingface.py
+++ b/tests/models/test_huggingface.py
@@ -19,6 +19,11 @@ task_manager = tasks.TaskManager()
 
 TEST_STRING = "foo bar"
 
+# Bound to names (not passed as string literals) so the *_token kwargs don't trip
+# ruff's flake8-bandit S105/S106 hardcoded-password false positive.
+OPEN_T = "<think>"
+CLOSE_T = "</think>"
+
 
 class Test_HFLM:
     torch.use_deterministic_algorithms(True)
@@ -151,3 +156,321 @@ class Test_HFLM:
             assert res == "foo bar\n<bazhang> !info bar"
         else:
             assert res == "foo bar\n<bazhang>!info bar"
+
+    def test_generate_until_length_info_bounds_batch_overflow(self) -> None:
+        """Regression: HF batched generation runs until ALL sequences in the batch
+        stop, so a short sequence over-generates past its own stop up to the batch max.
+        Per-response length/thinking-format must be measured on a bounded view (that
+        overflow trimmed), and the scored output must be unchanged.
+        """
+        from lm_eval.models.utils import postprocess_generated_text
+
+        eos = self.LM.tokenizer.eos_token_id
+        content = [t for t in self.LM.tok_encode("hello world foo bar") if t != eos][:3]
+
+        def _reqs(until):
+            return [
+                Instance(
+                    request_type="generate_until",
+                    doc={},
+                    arguments=("prompt", {"until": list(until), "max_gen_toks": 16}),
+                    idx=i,
+                    metadata=("t", i, 1),
+                )
+                for i in range(2)
+            ]
+
+        def _patch(rows):
+            def fake(context, attention_mask=None, stop=None, max_length=None, **kw):
+                gen = [rows for _ in range(context.shape[0])]
+                return torch.cat(
+                    [context, torch.tensor(gen, dtype=context.dtype)], dim=1
+                )
+
+            self.LM._model_generate = fake
+
+        _think_attrs = (
+            "think_end_token",
+            "think_start_token",
+            "think_end_token_str",
+            "track_thinking_metrics",
+            "think_open_prefilled",
+        )
+        saved = {k: getattr(self.LM, k, None) for k in _think_attrs}
+        try:
+            # (A) trailing-eos overflow: 3 real tokens + 7 eos -> length must be 3, not 10
+            _patch(content + [eos] * 7)
+            reqs = _reqs(["\n\n"])
+            self.LM.generate_until(reqs)
+            for r in reqs:
+                assert r.length_info[0]["response_length_tokens"] == 3, r.length_info
+
+            # (B) string-stop overflow: the row keeps emitting REAL tokens past its own
+            # stop (whole-batch stopping), so measurement must bound at STOP -> exactly
+            # the 2 tokens before it, not the full row.
+            stop_ids = [t for t in self.LM.tok_encode(" STOP") if t != eos]
+            stop_str = self.LM.tok_decode(stop_ids, skip_special_tokens=False)
+            row = content[:2] + stop_ids + [content[2], content[2]] + [eos] * 3
+            _patch(row)
+            reqs = _reqs([stop_str])
+            res = self.LM.generate_until(reqs)
+            bounded = self.LM.tok_decode(content[:2], skip_special_tokens=False)
+            for r in reqs:
+                info = r.length_info[0]
+                assert info["response_length_tokens"] == 2, info  # exact, not len(row)
+                assert info["response_length_chars"] == len(bounded), info
+            # (C) scoring unchanged vs the pre-fix postprocess of the full generation
+            assert res[0] == postprocess_generated_text(
+                self.LM.tok_decode(row), [stop_str], None
+            )
+
+            # (D) int-token close path: has_close/span from the RAW close boundary the
+            # strip uses; response_length from the bounded view (eos overflow excluded).
+            toks = [
+                t for t in self.LM.tok_encode("Alpha Bravo Charlie Delta") if t != eos
+            ]
+            O, R1, R2, A1 = toks[:4]
+            C = next(t for t in self.LM.tok_encode(" Zulu") if t != eos)
+            self.LM.think_end_token = C
+            self.LM.think_end_token_str = self.LM.tok_decode(
+                [C], skip_special_tokens=False
+            )
+            self.LM.think_start_token = self.LM.tok_decode(
+                [O], skip_special_tokens=False
+            )
+            self.LM.track_thinking_metrics = True
+            self.LM.think_open_prefilled = False
+            _patch([O, R1, R2, C, A1] + [eos] * 4)
+            reqs = _reqs(["\n\n"])
+            self.LM.generate_until(reqs)
+            info = reqs[0].length_info[0]
+            assert info["thinking_format_has_close"] == 1, info
+            assert info["thinking_format_correct"] == 1, info
+            assert info["thinking_length_tokens"] == 4, info  # [O,R1,R2,C]
+            assert info["response_length_tokens"] == 5, info  # eos overflow excluded
+            assert info["thinking_length_tokens"] <= info["response_length_tokens"]
+
+            # (E) int path, string stop BEFORE the close, close only in overflow: the
+            # bounded response opened but never closed, so has_close must be 0
+            # (batch-invariant), not 1 from a sibling-driven overflow close.
+            halt = [t for t in self.LM.tok_encode(" HALT") if t != eos]
+            halt_str = self.LM.tok_decode(halt, skip_special_tokens=False)
+            _patch([O, R1] + halt + [C, A1] + [eos] * 3)
+            reqs = _reqs([halt_str])
+            res_overflow = self.LM.generate_until(reqs)
+            info = reqs[0].length_info[0]
+            assert info["thinking_format_has_open"] == 1, info
+            assert info["thinking_format_has_close"] == 0, (
+                info
+            )  # overflow close excluded
+            assert info["thinking_format_correct"] == 0, info
+            assert "thinking_length_tokens" not in info, info
+            # exact bounded count: only [O, R1] precede the stop
+            assert info["response_length_tokens"] == 2, info
+
+            # (F) SCORING must agree with the metric and be batch-invariant. The same
+            # doc without overflow (no close, no answer past the stop) must score
+            # identically: the strip may only key off an IN-BOUNDS close, never one
+            # that exists solely because a batch sibling kept the batch generating.
+            _patch([O, R1] + halt + [eos] * 4)  # what bs=1 would have produced
+            reqs = _reqs([halt_str])
+            res_bs1 = self.LM.generate_until(reqs)
+            assert res_overflow[0] == res_bs1[0], (
+                f"scored text is batch-dependent: {res_overflow[0]!r} vs {res_bs1[0]!r}"
+            )
+            # metric said has_close=0, so nothing may have been stripped at a close
+            assert reqs[0].length_info[0]["thinking_format_has_close"] == 0
+        finally:
+            self.LM.__dict__.pop("_model_generate", None)  # restore the bound method
+            for k, v in saved.items():  # restore think attrs to their __init__ values
+                setattr(self.LM, k, v)
+
+    def test_int_close_uses_in_context_close_string(self) -> None:
+        """`correct` must not depend on how the close token decodes in ISOLATION.
+
+        On the int path the format order/re-open checks string-search the close inside
+        `gen_text`, which renders the token IN CONTEXT. `think_end_token_str` is decoded
+        from the id alone and can differ (leading space, merge). If the search misses,
+        every well-formed response would be flagged malformed and lose its
+        `thinking_length_*`. The close string must instead be read off the token offsets.
+        """
+        eos = self.LM.tokenizer.eos_token_id
+        nz = [t for t in self.LM.tok_encode("Alpha reason answer") if t != eos]
+        O, R, A = nz[0], nz[1], nz[2]
+        C = next(t for t in self.LM.tok_encode(" Zulu") if t != eos)
+
+        saved = {
+            k: getattr(self.LM, k, None)
+            for k in (
+                "think_end_token",
+                "think_start_token",
+                "think_end_token_str",
+                "track_thinking_metrics",
+                "think_open_prefilled",
+            )
+        }
+        try:
+            self.LM.think_end_token = C
+            self.LM.think_start_token = self.LM.tok_decode(
+                [O], skip_special_tokens=False
+            )
+            # deliberately WRONG isolated decode: the old code string-searched this and
+            # missed, yielding correct=0 for a perfectly well-formed response.
+            self.LM.think_end_token_str = "###NEVER-APPEARS###"
+            self.LM.track_thinking_metrics = True
+            self.LM.think_open_prefilled = False
+
+            def fake(context, attention_mask=None, stop=None, max_length=None, **kw):
+                gen = [[O, R, C, A] + [eos] * 3]
+                return torch.cat(
+                    [context, torch.tensor(gen, dtype=context.dtype)], dim=1
+                )
+
+            self.LM._model_generate = fake
+            req = Instance(
+                request_type="generate_until",
+                doc={},
+                arguments=("p", {"until": ["\n\n"], "max_gen_toks": 16}),
+                idx=0,
+                metadata=("t", 0, 1),
+            )
+            self.LM.generate_until([req])
+            info = req.length_info[0]
+            assert info["thinking_format_has_close"] == 1, info
+            assert info["thinking_format_correct"] == 1, info  # was 0 before the fix
+            assert info["thinking_length_tokens"] == 3, info  # [O, R, C]
+        finally:
+            self.LM.__dict__.pop("_model_generate", None)
+            for k, v in saved.items():
+                setattr(self.LM, k, v)
+
+    def test_special_token_close_is_stripped_at_token_level(self) -> None:
+        """A close erased by `skip_special_tokens=True` must still strip.
+
+        The scored text comes from `tok_decode(...)` (skip_special_tokens=True). A close
+        registered as a *special* token (DeepSeek-R1 style) is dropped there, so a string
+        strip could never find it: the reasoning would survive, glued to the answer.
+        Such a close must be routed through the token-id strip instead. A plain added
+        token (Qwen3 style) survives the decode and must keep the string path.
+        """
+        from transformers import AutoTokenizer
+
+        def build(special: bool):
+            tok = AutoTokenizer.from_pretrained("EleutherAI/pythia-70m")
+            if special:
+                tok.add_special_tokens({"additional_special_tokens": [OPEN_T, CLOSE_T]})
+            else:
+                tok.add_tokens([OPEN_T, CLOSE_T])
+            close = {"think_end_token": CLOSE_T}
+            lm = HFLM(
+                pretrained="EleutherAI/pythia-70m",
+                tokenizer=tok,
+                device="cpu",
+                **close,
+            )
+            row = tok.encode(f"reason{CLOSE_T}answer")
+
+            def fake(context, attention_mask=None, stop=None, max_length=None, **kw):
+                return torch.cat(
+                    [context, torch.tensor([row], dtype=context.dtype)], dim=1
+                )
+
+            lm._model_generate = fake
+            req = Instance(
+                request_type="generate_until",
+                doc={},
+                arguments=("p", {"until": ["\n\n"], "max_gen_toks": 16}),
+                idx=0,
+                metadata=("t", 0, 1),
+            )
+            return lm, lm.generate_until([req])[0], req.length_info[0]
+
+        # special close -> demoted to its token id so the id-based strip can fire
+        lm, scored, info = build(special=True)
+        assert isinstance(lm.think_end_token, int), lm.think_end_token
+        assert lm.think_end_token_str == CLOSE_T
+        assert scored == "answer", scored  # NOT 'reasonanswer'
+        assert info["thinking_format_correct"] == 1, info
+
+        # plain added close -> survives the scoring decode, keeps the string path
+        lm, scored, info = build(special=False)
+        assert lm.think_end_token == CLOSE_T
+        assert scored == "answer", scored
+        assert info["thinking_format_correct"] == 1, info
+
+    def test_track_thinking_metrics_override(self) -> None:
+        """Tracking derives from the close token alone; `enable_thinking` never gates it."""
+
+        def lm(**kw):
+            return HFLM(pretrained="EleutherAI/pythia-70m", device="cpu", **kw)
+
+        close = {"think_end_token": CLOSE_T}
+        # derived: on whenever a close is known, regardless of the reasoning mode
+        assert lm(**close).track_thinking_metrics is True
+        assert lm(**close, enable_thinking=False).track_thinking_metrics is True
+        # forced off / forced on, independently of enable_thinking
+        assert lm(**close, track_thinking_metrics=False).track_thinking_metrics is False
+        assert (
+            lm(
+                **close, enable_thinking=False, track_thinking_metrics=True
+            ).track_thinking_metrics
+            is True
+        )
+        # cannot track without a close token (has_close / the span are undefined)
+        assert lm(track_thinking_metrics=True).track_thinking_metrics is False
+        # an open alone is not enough either
+        open_only = {"think_start_token": OPEN_T}
+        assert (
+            lm(**open_only, track_thinking_metrics=True).track_thinking_metrics is False
+        )
+
+    def test_autodetect_think_tokens_matrix(self) -> None:
+        """End-to-end decoupling on a real model with a synthetic reasoning template.
+
+        `enable_thinking` must not influence detection, the strip, or the metrics;
+        `autodetect_think_tokens` is the only lever over template scanning.
+        """
+        from transformers import AutoTokenizer
+
+        tok = AutoTokenizer.from_pretrained("EleutherAI/pythia-70m")
+        tok.chat_template = (
+            "{% set inner_token = '<think>' %}{% set outer_token = '</think>' %}"
+        )
+
+        def lm(**kw):
+            return HFLM(
+                pretrained="EleutherAI/pythia-70m", tokenizer=tok, device="cpu", **kw
+            )
+
+        # DEFAULT: autodetect is opt-in, so a reasoning template is NOT scanned.
+        # No close -> no strip, no thinking metrics.
+        m = lm()
+        assert (m.think_start_token, m.think_end_token) == (None, None)
+        assert m.track_thinking_metrics is False
+
+        # opt in -> tokens detected -> strip armed (think_end_token set) + metrics on
+        m = lm(autodetect_think_tokens=True)
+        assert (m.think_start_token, m.think_end_token) == (OPEN_T, CLOSE_T)
+        assert m.track_thinking_metrics is True
+
+        # enable_thinking must NOT influence detection either way (the decoupling)
+        m = lm(autodetect_think_tokens=True, enable_thinking=False)
+        assert m.think_end_token == CLOSE_T
+        assert m.track_thinking_metrics is True
+        m = lm(enable_thinking=True)  # autodetect still off -> still nothing
+        assert m.think_end_token is None
+        assert m.track_thinking_metrics is False
+
+        # an explicit close works without autodetect (deliberate strip request)
+        close = {"think_end_token": CLOSE_T}
+        m = lm(**close)
+        assert m.think_end_token == CLOSE_T
+        assert m.think_start_token is None  # not detected; close-only style
+        assert m.track_thinking_metrics is True
+
+        # open only -> nothing to strip or measure
+        open_only = {"think_start_token": OPEN_T}
+        m = lm(**open_only)
+        assert m.think_start_token == OPEN_T
+        assert m.think_end_token is None
+        assert m.track_thinking_metrics is False

--- a/tests/models/test_model_utils.py
+++ b/tests/models/test_model_utils.py
@@ -1,8 +1,11 @@
 import pytest
 
 from lm_eval.models.utils import (
+    build_length_info,
     check_system_boilerplate,
+    compute_generation_length_info,
     compute_thinking_format_info,
+    detect_open_prefilled,
     detect_think_end_token,
     detect_think_start_token,
     get_template_special_tokens,
@@ -553,13 +556,14 @@ class TestDetectThinkTokens:
 
 
 class TestComputeThinkingFormatInfo:
-    def test_prefilled_open_in_prompt(self):
-        # open prefilled into the prompt, close emitted by the model
+    def test_prefill_normal(self):
+        # prefill template: the open is injected by the generation prompt (open_prefilled),
+        # the model emits only the close.
         info = compute_thinking_format_info(
             "reasoning</think>answer",
-            context="<think>",
             think_start_token=OPEN_T,
             think_end_token=CLOSE_T,
+            open_prefilled=True,
         )
         assert info == {
             "thinking_format_has_open": 1,
@@ -567,74 +571,246 @@ class TestComputeThinkingFormatInfo:
             "thinking_format_correct": 1,
         }
 
-    def test_open_generated_by_model(self):
+    def test_non_prefill_open_generated_by_model(self):
         info = compute_thinking_format_info(
             "<think>reasoning</think>answer",
-            context="",
             think_start_token=OPEN_T,
             think_end_token=CLOSE_T,
+            open_prefilled=False,
         )
         assert info["thinking_format_has_open"] == 1
         assert info["thinking_format_has_close"] == 1
         assert info["thinking_format_correct"] == 1
 
-    def test_missing_close(self):
+    def test_prefill_missing_close(self):
         info = compute_thinking_format_info(
             "reasoning with no close",
-            context="<think>",
             think_start_token=OPEN_T,
             think_end_token=CLOSE_T,
+            open_prefilled=True,
         )
         assert info["thinking_format_has_open"] == 1
         assert info["thinking_format_has_close"] == 0
         assert info["thinking_format_correct"] == 0
 
-    def test_missing_open(self):
+    def test_non_prefill_open_no_close(self):
         info = compute_thinking_format_info(
-            "reasoning</think>answer",
-            context="",
+            "<think>still reasoning",
             think_start_token=OPEN_T,
             think_end_token=CLOSE_T,
+            open_prefilled=False,
+        )
+        assert info["thinking_format_has_open"] == 1
+        assert info["thinking_format_has_close"] == 0
+        assert info["thinking_format_correct"] == 0
+
+    def test_non_prefill_bare_close_not_correct(self):
+        # Multi-turn correctness: a non-prefill turn that emits ONLY a close (open not
+        # this turn) must read has_open=0, correct=0 — the history is never consulted,
+        # so a prior turn's leaked open cannot inflate the signal.
+        info = compute_thinking_format_info(
+            "here is the answer</think>done",
+            think_start_token=OPEN_T,
+            think_end_token=CLOSE_T,
+            open_prefilled=False,
         )
         assert info["thinking_format_has_open"] == 0
         assert info["thinking_format_has_close"] == 1
         assert info["thinking_format_correct"] == 0
 
     def test_reversed_order_not_correct(self):
-        # close appears before open in the generation -> malformed
+        # close before open in the generation -> malformed
         info = compute_thinking_format_info(
             "</think>stuff<think>",
-            context="",
             think_start_token=OPEN_T,
             think_end_token=CLOSE_T,
+            open_prefilled=False,
         )
         assert info["thinking_format_correct"] == 0
 
     def test_reopen_after_close_with_prefilled_open_not_correct(self):
-        # prefilled open in the prompt, model closes then re-opens -> malformed.
-        # (a bare open<close ordering check would wrongly pass here.)
+        # prefilled open, model closes then re-opens -> malformed.
         info = compute_thinking_format_info(
             "reasoning</think>answer<think>oops",
-            context="<think>",
             think_start_token=OPEN_T,
             think_end_token=CLOSE_T,
+            open_prefilled=True,
         )
         assert info["thinking_format_has_open"] == 1
         assert info["thinking_format_has_close"] == 1
         assert info["thinking_format_correct"] == 0
 
-    def test_no_tokens_known_returns_empty(self):
-        assert compute_thinking_format_info("hi", context="") == {}
-
-    def test_only_close_known(self):
+    def test_multiple_closes_reopen_detected_from_first_close(self):
+        # close, reopen, close again -> the reopen between the two closes must still
+        # be caught (probe from the FIRST close, not the last).
         info = compute_thinking_format_info(
-            "x</think>y", context="", think_end_token=CLOSE_T
+            "<think>a</think>b<think>c</think>d",
+            think_start_token=OPEN_T,
+            think_end_token=CLOSE_T,
+            open_prefilled=False,
         )
-        assert info == {"thinking_format_has_close": 1}
+        assert info["thinking_format_has_close"] == 1
+        assert info["thinking_format_correct"] == 0
+
+    def test_multiple_closes_without_reopen_is_correct(self):
+        # one open, a stray extra close, no second open -> still well-formed.
+        info = compute_thinking_format_info(
+            "<think>a</think>b</think>c",
+            think_start_token=OPEN_T,
+            think_end_token=CLOSE_T,
+            open_prefilled=False,
+        )
+        assert info["thinking_format_correct"] == 1
+
+    def test_close_only_model_correct_equals_has_close(self):
+        # No open token known (close-only model): correct reduces to has_close, and
+        # has_open is not emitted.
+        closed = compute_thinking_format_info(
+            "reasoning</think>answer", think_end_token=CLOSE_T
+        )
+        assert closed == {
+            "thinking_format_has_close": 1,
+            "thinking_format_correct": 1,
+        }
+        not_closed = compute_thinking_format_info(
+            "reasoning, never closed", think_end_token=CLOSE_T
+        )
+        assert not_closed == {
+            "thinking_format_has_close": 0,
+            "thinking_format_correct": 0,
+        }
+
+    def test_no_tokens_known_returns_empty(self):
+        assert compute_thinking_format_info("hi") == {}
 
     def test_never_raises_on_bad_input(self):
         # non-str generation should be swallowed, returning {}
-        assert compute_thinking_format_info(None, context=None) == {}
+        assert compute_thinking_format_info(None) == {}
+
+
+class TestComputeGenerationLengthInfo:
+    def test_response_length_basic(self):
+        info = compute_generation_length_info("one two three", token_ids=[1, 2, 3])
+        assert info["response_length_words"] == 3
+        assert info["response_length_chars"] == len("one two three")
+        assert info["response_length_tokens"] == 3
+        assert "thinking_length_chars" not in info
+
+    def test_no_close_omits_thinking_span(self):
+        info = compute_generation_length_info("no close here", think_end_token=CLOSE_T)
+        assert "thinking_length_chars" not in info
+
+    def test_thinking_span_uses_last_close(self):
+        # the strip keeps text after the LAST close, so the thinking span must too.
+        raw = "<think>a</think>b</think>c"
+        info = compute_generation_length_info(raw, think_end_token=CLOSE_T)
+        expected = "<think>a</think>b</think>"  # up to and including the last close
+        assert info["thinking_length_chars"] == len(expected)
+        assert info["response_length_chars"] == len(raw)
+        assert info["thinking_length_chars"] <= info["response_length_chars"]
+
+    def test_thinking_span_measured_without_open_token(self):
+        # multi-turn: a turn may CLOSE a block whose open was prefilled/earlier. The
+        # helper sees only THIS turn's text and measures start..last-close regardless
+        # of whether an open token is present (length is close-driven, open-agnostic).
+        gen = "continued reasoning</think>final answer"
+        info = compute_generation_length_info(gen, think_end_token=CLOSE_T)
+        expected_think = "continued reasoning</think>"
+        assert info["thinking_length_chars"] == len(expected_think)
+        assert info["thinking_length_chars"] <= info["response_length_chars"]
+
+    def test_open_without_close_omits_thinking_span(self):
+        # A turn with no close has no boundary, so no thinking_length is recorded
+        # (and it is simply absent from the aggregate, not zero-filled).
+        gen = "<think>still reasoning, no close"
+        info = compute_generation_length_info(gen, think_end_token=CLOSE_T)
+        assert "thinking_length_chars" not in info
+        assert info["response_length_chars"] == len(gen)
+
+    def test_measure_thinking_false_suppresses_span(self):
+        # The backend passes measure_thinking only for well-formed responses; when
+        # False, the thinking span is not recorded even though a close is present.
+        info = compute_generation_length_info(
+            "r</think>a", think_end_token=CLOSE_T, measure_thinking=False
+        )
+        assert "thinking_length_chars" not in info
+        assert info["response_length_chars"] == len("r</think>a")
+
+
+class TestDetectOpenPrefilled:
+    def test_prefill_template_detected(self):
+        render = lambda h, add_generation_prompt=True: "<|user|>x<|assistant|><think>"  # noqa: E731
+        assert detect_open_prefilled(render, OPEN_T) is True
+
+    def test_non_prefill_template_not_detected(self):
+        render = lambda h, add_generation_prompt=True: "<|user|>x<|assistant|>"  # noqa: E731
+        assert detect_open_prefilled(render, OPEN_T) is False
+
+    def test_no_open_token_is_false(self):
+        render = lambda h, add_generation_prompt=True: "<think>"  # noqa: E731
+        assert detect_open_prefilled(render, None) is False
+
+    def test_render_failure_is_false(self):
+        def render(h, add_generation_prompt=True):
+            raise RuntimeError("boom")
+
+        assert detect_open_prefilled(render, OPEN_T) is False
+
+
+class TestBuildLengthInfo:
+    """Shared string-close builder (vllm/sglang/hf): format-first, so the thinking
+    span is recorded only for well-formed responses.
+    """
+
+    def test_well_formed_records_thinking(self):
+        info = build_length_info(
+            "<think>reason</think>ans",
+            token_ids=[1, 2, 3],
+            think_start_token=OPEN_T,
+            think_end_token=CLOSE_T,
+            open_prefilled=False,
+            track_thinking_metrics=True,
+        )
+        assert info["thinking_format_correct"] == 1
+        assert info["response_length_tokens"] == 3
+        assert "thinking_length_chars" in info
+        assert info["thinking_length_chars"] <= info["response_length_chars"]
+
+    def test_malformed_omits_thinking_but_keeps_response(self):
+        # open but no close -> correct=0 -> no thinking_length, response still measured.
+        info = build_length_info(
+            "<think>reason with no close",
+            think_start_token=OPEN_T,
+            think_end_token=CLOSE_T,
+            open_prefilled=False,
+            track_thinking_metrics=True,
+        )
+        assert info["thinking_format_correct"] == 0
+        assert "thinking_length_chars" not in info
+        assert info["response_length_chars"] == len("<think>reason with no close")
+
+    def test_prefilled_open_records_thinking(self):
+        # non-prefill would read has_open=0 here; open_prefilled=True makes it well-formed.
+        info = build_length_info(
+            "reason</think>ans",
+            think_start_token=OPEN_T,
+            think_end_token=CLOSE_T,
+            open_prefilled=True,
+            track_thinking_metrics=True,
+        )
+        assert info["thinking_format_has_open"] == 1
+        assert info["thinking_format_correct"] == 1
+        assert "thinking_length_chars" in info
+
+    def test_untracked_emits_only_response_length(self):
+        info = build_length_info(
+            "<think>reason</think>ans",
+            think_start_token=OPEN_T,
+            think_end_token=CLOSE_T,
+            track_thinking_metrics=False,
+        )
+        assert not any(k.startswith("thinking_") for k in info)
+        assert info["response_length_chars"] == len("<think>reason</think>ans")
 
 
 class TestResolveThinkTokens:

--- a/tests/models/test_model_utils.py
+++ b/tests/models/test_model_utils.py
@@ -11,9 +11,12 @@ from lm_eval.models.utils import (
     get_template_special_tokens,
     maybe_truncate,
     normalize_gen_kwargs,
+    postprocess_generated_text,
     resolve_think_tokens,
+    resolve_track_thinking_metrics,
     strip_system_boilerplate_from_template,
     template_declares_reasoning,
+    truncate_before_stops,
     truncate_tokens,
 )
 
@@ -812,8 +815,52 @@ class TestBuildLengthInfo:
         assert not any(k.startswith("thinking_") for k in info)
         assert info["response_length_chars"] == len("<think>reason</think>ans")
 
+    def test_absent_open_degrades_to_close_only(self):
+        # The close alone is enough to track: `correct` reduces to `has_close`, the
+        # thinking span is still measured, and `has_open` is simply not emitted.
+        info = build_length_info(
+            "reason</think>ans",
+            think_start_token=None,
+            think_end_token=CLOSE_T,
+            track_thinking_metrics=True,
+        )
+        assert "thinking_format_has_open" not in info
+        assert info["thinking_format_has_close"] == 1
+        assert info["thinking_format_correct"] == 1
+        assert info["thinking_length_chars"] == len("reason</think>")
+
+    def test_absent_close_emits_no_correct_and_no_span(self):
+        # Defensive: `track_thinking_metrics` never turns on without a close (the backend
+        # gates on it), but if it did, nothing may be mis-attributed — no `correct`, no
+        # thinking span, and `response_length_*` still recorded.
+        info = build_length_info(
+            "<think>reason with no close",
+            think_start_token=OPEN_T,
+            think_end_token=None,
+            track_thinking_metrics=True,
+        )
+        assert info["thinking_format_has_open"] == 1
+        assert "thinking_format_has_close" not in info
+        assert "thinking_format_correct" not in info
+        assert not any(k.startswith("thinking_length_") for k in info)
+        assert info["response_length_chars"] == len("<think>reason with no close")
+
+    def test_both_tokens_absent_emits_only_response_length(self):
+        info = build_length_info(
+            "just an answer",
+            think_start_token=None,
+            think_end_token=None,
+            track_thinking_metrics=True,
+        )
+        assert not any(k.startswith("thinking_") for k in info)
+        assert info["response_length_chars"] == len("just an answer")
+
 
 class TestResolveThinkTokens:
+    """The 2nd arg is `autodetect`, NOT `enable_thinking`: template scanning is gated on
+    the dedicated flag, so the reasoning mode never decides whether the strip is armed.
+    """
+
     def test_auto_detect(self):
         assert resolve_think_tokens(SIMPLE_TPL, True, None, None) == (
             "<think>",
@@ -827,7 +874,9 @@ class TestResolveThinkTokens:
     def test_no_raise_for_plain_template(self):
         assert resolve_think_tokens(PLAIN_TPL, True, None, None) == (None, None)
 
-    def test_no_raise_when_thinking_disabled(self):
+    def test_autodetect_off_suppresses_fail_loud(self):
+        # the new escape hatch: autodetect=False never scans the template, so an
+        # unparseable close cannot raise (works on every backend, incl. sglang).
         tpl = "{% set inner_token = x %}{% set outer_token = y %}"  # unparseable values
         assert resolve_think_tokens(tpl, False, None, None) == (None, None)
 
@@ -836,11 +885,27 @@ class TestResolveThinkTokens:
         with pytest.raises(ValueError, match="close"):
             resolve_think_tokens(tpl, True, None, None)
 
+    def test_fail_loud_message_names_the_escape_hatches(self):
+        tpl = "{% set inner_token = x %}{% set outer_token = y %}"
+        with pytest.raises(ValueError) as exc:
+            resolve_think_tokens(tpl, True, None, None)
+        msg = str(exc.value)
+        assert "think_end_token=" in msg
+        assert "autodetect_think_tokens=false" in msg
+        # the old, now-nonexistent escape must not be advertised
+        assert "enable_thinking" not in msg
+
     def test_missing_open_only_warns_not_raises(self):
         # close is parseable, open is not: the strip/length work, so don't abort —
         # only the (non-fatal) format open metric is dropped.
         tpl = "{% set inner_token = x %}{% set outer_token = '</think>' %}"
         assert resolve_think_tokens(tpl, True, None, None) == (None, "</think>")
+
+    def test_open_without_close_returns_open_and_no_close(self):
+        # An open alone cannot arm the strip or any thinking metric (all key off the
+        # close). Resolution still surfaces the open; the caller must not crash.
+        assert resolve_think_tokens(PLAIN_TPL, True, OPEN_T, None) == (OPEN_T, None)
+        assert resolve_think_tokens(PLAIN_TPL, False, OPEN_T, None) == (OPEN_T, None)
 
     def test_forcing_suppresses_fail_loud(self):
         tpl = "{% set inner_token = x %}{% set outer_token = y %}"
@@ -850,3 +915,106 @@ class TestResolveThinkTokens:
         # an explicit close (e.g. HF int decoded to a string) avoids the close raise
         tpl = "{% set inner_token = x %}{% set outer_token = y %}"
         assert resolve_think_tokens(tpl, True, None, "</think>") == (None, "</think>")
+
+    def test_autodetect_off_skips_detection_even_when_parseable(self):
+        # autodetect=False must NOT read a perfectly parseable reasoning template:
+        # no close -> no strip and no thinking metrics.
+        assert resolve_think_tokens(SIMPLE_TPL, False, None, None) == (None, None)
+
+    def test_autodetect_off_still_honors_explicit_tokens(self):
+        # explicit > flag: a forced close is a deliberate strip request.
+        assert resolve_think_tokens(SIMPLE_TPL, False, None, "</x>") == (None, "</x>")
+        assert resolve_think_tokens(SIMPLE_TPL, False, "<s>", "</s>") == ("<s>", "</s>")
+
+    def test_thinking_mode_does_not_gate_detection(self):
+        # The decoupling lock: there is no `enable_thinking` lever left in this helper.
+        # Whatever the reasoning mode, autodetect=True detects and autodetect=False does not.
+        assert resolve_think_tokens(SIMPLE_TPL, True, None, None) == (OPEN_T, CLOSE_T)
+        assert resolve_think_tokens(SIMPLE_TPL, False, None, None) == (None, None)
+
+
+class TestResolveTrackThinkingMetrics:
+    """Tracking derives from the CLOSE token alone. None = derive; True/False = force.
+    A missing open is fine (close-only style); a missing close disables everything.
+    """
+
+    def test_derived_from_close_token(self):
+        assert resolve_track_thinking_metrics(None, CLOSE_T) is True
+
+    def test_derived_requires_close_token(self):
+        assert resolve_track_thinking_metrics(None, None) is False
+
+    def test_derived_ignores_absence_of_thinking_flag(self):
+        # Decoupling lock: `enable_thinking` is not a lever here, so a close token alone
+        # is sufficient to track regardless of the model's reasoning mode.
+        import inspect
+
+        assert (
+            "enable_thinking"
+            not in inspect.signature(resolve_track_thinking_metrics).parameters
+        )
+
+    def test_force_off(self):
+        assert resolve_track_thinking_metrics(False, CLOSE_T) is False
+
+    def test_force_on(self):
+        assert resolve_track_thinking_metrics(True, CLOSE_T) is True
+
+    def test_force_on_without_close_token_warns_and_stays_off(self):
+        # has_close / the thinking span are undefined without a close -> cannot track
+        assert resolve_track_thinking_metrics(True, None) is False
+
+    def test_open_only_still_cannot_track(self):
+        # An open token is irrelevant here: only the close is passed, and without it
+        # tracking stays off even when forced.
+        assert resolve_track_thinking_metrics(None, None) is False
+        assert resolve_track_thinking_metrics(True, None) is False
+
+    def test_returns_plain_bool(self):
+        # promoted flags must stay ints/bools, never a truthy string
+        assert resolve_track_thinking_metrics(1, CLOSE_T) is True
+        assert resolve_track_thinking_metrics(0, CLOSE_T) is False
+
+    def test_int_token_id_zero_is_a_known_close(self):
+        # `0` is a valid token id; a plain truthiness test would silently disable
+        # tracking for it. "Known" means not None and not the empty string.
+        assert resolve_track_thinking_metrics(None, 0) is True
+        assert resolve_track_thinking_metrics(False, 0) is False
+        assert resolve_track_thinking_metrics(None, 42) is True
+        # ...while an empty close is still "unknown"
+        assert resolve_track_thinking_metrics(None, "") is False
+        assert resolve_track_thinking_metrics(True, "") is False
+
+
+class TestTruncateBeforeStops:
+    def test_truncates_at_earliest_stop(self):
+        assert truncate_before_stops("answer\n\nmore", ["\n\n"]) == "answer"
+
+    def test_earliest_of_multiple_stops_wins(self):
+        # order-independent: cut at whichever stop occurs first in the text
+        assert truncate_before_stops("aXbYc", ["Y", "X"]) == "a"
+        assert truncate_before_stops("aXbYc", ["X", "Y"]) == "a"
+
+    def test_no_stop_present_is_identity(self):
+        assert truncate_before_stops("clean answer", ["\n\n"]) == "clean answer"
+
+    def test_empty_and_none_stops_are_identity(self):
+        assert truncate_before_stops("text", []) == "text"
+        assert truncate_before_stops("text", None) == "text"
+        assert truncate_before_stops("text", "") == "text"
+
+    def test_string_stop_accepted(self):
+        assert truncate_before_stops("a<stop>b", "<stop>") == "a"
+
+    def test_empty_term_ignored(self):
+        # a '' stop term (e.g. seq2seq eos decoding to '') must not truncate to ''
+        assert truncate_before_stops("hello", ["", "\n"]) == "hello"
+
+    def test_matches_postprocess_stop_phase(self):
+        # truncate_before_stops must reproduce exactly the stop-truncation half of
+        # postprocess_generated_text (no thinking strip) — the boundary HF length
+        # measurement relies on to match the scored text.
+        text = "reasoning</think>the answer\n\noverflow"
+        assert truncate_before_stops(text, ["\n\n"]) == postprocess_generated_text(
+            text, ["\n\n"], None
+        )

--- a/tests/models/test_model_utils.py
+++ b/tests/models/test_model_utils.py
@@ -2,10 +2,15 @@ import pytest
 
 from lm_eval.models.utils import (
     check_system_boilerplate,
+    compute_thinking_format_info,
+    detect_think_end_token,
+    detect_think_start_token,
     get_template_special_tokens,
     maybe_truncate,
     normalize_gen_kwargs,
+    resolve_think_tokens,
     strip_system_boilerplate_from_template,
+    template_declares_reasoning,
     truncate_tokens,
 )
 
@@ -500,3 +505,172 @@ class TestStripSystemBoilerplate:
 
     def test_none_input_returns_none(self):
         assert strip_system_boilerplate_from_template(None) is None
+
+
+SIMPLE_TPL = "{% set inner_token = '<think>' %}{% set outer_token = '</think>' %}"
+SPECIAL_TPL = (
+    "{% set inner_token = '<|inner_prefix|>' %}"
+    "{% set outer_token = '<|inner_suffix|>' %}"
+)
+PLAIN_TPL = "hello {{ messages }}"
+
+# Bound to names (not passed as string literals) so the *_token kwargs don't trip
+# ruff's flake8-bandit S106 hardcoded-password false positive.
+OPEN_T = "<think>"
+CLOSE_T = "</think>"
+
+
+class TestDetectThinkTokens:
+    def test_detect_start_and_end(self):
+        assert detect_think_start_token(SIMPLE_TPL) == "<think>"
+        assert detect_think_end_token(SIMPLE_TPL) == "</think>"
+
+    def test_detect_special_token_forms(self):
+        assert detect_think_start_token(SPECIAL_TPL) == "<|inner_prefix|>"
+        assert detect_think_end_token(SPECIAL_TPL) == "<|inner_suffix|>"
+
+    def test_last_assignment_wins(self):
+        tpl = "{% set inner_token = '<a>' %}{% set inner_token = '<b>' %}"
+        assert detect_think_start_token(tpl) == "<b>"
+
+    def test_none_when_absent_or_empty(self):
+        assert detect_think_start_token(PLAIN_TPL) is None
+        assert detect_think_end_token(PLAIN_TPL) is None
+        assert detect_think_start_token(None) is None
+
+    def test_template_declares_reasoning(self):
+        assert template_declares_reasoning(SIMPLE_TPL) is True
+        assert template_declares_reasoning("{% set outer_token = '</t>' %}") is True
+        assert template_declares_reasoning(PLAIN_TPL) is False
+        assert template_declares_reasoning(None) is False
+
+    def test_word_boundary_avoids_false_positive(self):
+        # identifiers merely ending in inner_token/outer_token must not match
+        assert template_declares_reasoning("{% set winner_token = x %}") is False
+        assert template_declares_reasoning("{% set router_token = y %}") is False
+        assert detect_think_start_token("{% set winner_token = '<w>' %}") is None
+        assert detect_think_end_token("{% set router_token = '<r>' %}") is None
+
+
+class TestComputeThinkingFormatInfo:
+    def test_prefilled_open_in_prompt(self):
+        # open prefilled into the prompt, close emitted by the model
+        info = compute_thinking_format_info(
+            "reasoning</think>answer",
+            context="<think>",
+            think_start_token=OPEN_T,
+            think_end_token=CLOSE_T,
+        )
+        assert info == {
+            "thinking_format_has_open": 1,
+            "thinking_format_has_close": 1,
+            "thinking_format_correct": 1,
+        }
+
+    def test_open_generated_by_model(self):
+        info = compute_thinking_format_info(
+            "<think>reasoning</think>answer",
+            context="",
+            think_start_token=OPEN_T,
+            think_end_token=CLOSE_T,
+        )
+        assert info["thinking_format_has_open"] == 1
+        assert info["thinking_format_has_close"] == 1
+        assert info["thinking_format_correct"] == 1
+
+    def test_missing_close(self):
+        info = compute_thinking_format_info(
+            "reasoning with no close",
+            context="<think>",
+            think_start_token=OPEN_T,
+            think_end_token=CLOSE_T,
+        )
+        assert info["thinking_format_has_open"] == 1
+        assert info["thinking_format_has_close"] == 0
+        assert info["thinking_format_correct"] == 0
+
+    def test_missing_open(self):
+        info = compute_thinking_format_info(
+            "reasoning</think>answer",
+            context="",
+            think_start_token=OPEN_T,
+            think_end_token=CLOSE_T,
+        )
+        assert info["thinking_format_has_open"] == 0
+        assert info["thinking_format_has_close"] == 1
+        assert info["thinking_format_correct"] == 0
+
+    def test_reversed_order_not_correct(self):
+        # close appears before open in the generation -> malformed
+        info = compute_thinking_format_info(
+            "</think>stuff<think>",
+            context="",
+            think_start_token=OPEN_T,
+            think_end_token=CLOSE_T,
+        )
+        assert info["thinking_format_correct"] == 0
+
+    def test_reopen_after_close_with_prefilled_open_not_correct(self):
+        # prefilled open in the prompt, model closes then re-opens -> malformed.
+        # (a bare open<close ordering check would wrongly pass here.)
+        info = compute_thinking_format_info(
+            "reasoning</think>answer<think>oops",
+            context="<think>",
+            think_start_token=OPEN_T,
+            think_end_token=CLOSE_T,
+        )
+        assert info["thinking_format_has_open"] == 1
+        assert info["thinking_format_has_close"] == 1
+        assert info["thinking_format_correct"] == 0
+
+    def test_no_tokens_known_returns_empty(self):
+        assert compute_thinking_format_info("hi", context="") == {}
+
+    def test_only_close_known(self):
+        info = compute_thinking_format_info(
+            "x</think>y", context="", think_end_token=CLOSE_T
+        )
+        assert info == {"thinking_format_has_close": 1}
+
+    def test_never_raises_on_bad_input(self):
+        # non-str generation should be swallowed, returning {}
+        assert compute_thinking_format_info(None, context=None) == {}
+
+
+class TestResolveThinkTokens:
+    def test_auto_detect(self):
+        assert resolve_think_tokens(SIMPLE_TPL, True, None, None) == (
+            "<think>",
+            "</think>",
+        )
+
+    def test_forced_args_skip_detection(self):
+        # forced values win even on a plain template
+        assert resolve_think_tokens(PLAIN_TPL, True, "<s>", "</s>") == ("<s>", "</s>")
+
+    def test_no_raise_for_plain_template(self):
+        assert resolve_think_tokens(PLAIN_TPL, True, None, None) == (None, None)
+
+    def test_no_raise_when_thinking_disabled(self):
+        tpl = "{% set inner_token = x %}{% set outer_token = y %}"  # unparseable values
+        assert resolve_think_tokens(tpl, False, None, None) == (None, None)
+
+    def test_fail_loud_when_close_undetectable(self):
+        tpl = "{% set inner_token = x %}{% set outer_token = y %}"  # declares but no quotes
+        with pytest.raises(ValueError, match="close"):
+            resolve_think_tokens(tpl, True, None, None)
+
+    def test_missing_open_only_warns_not_raises(self):
+        # close is parseable, open is not: the strip/length work, so don't abort —
+        # only the (non-fatal) format open metric is dropped.
+        tpl = "{% set inner_token = x %}{% set outer_token = '</think>' %}"
+        assert resolve_think_tokens(tpl, True, None, None) == (None, "</think>")
+
+    def test_forcing_suppresses_fail_loud(self):
+        tpl = "{% set inner_token = x %}{% set outer_token = y %}"
+        assert resolve_think_tokens(tpl, True, "<s>", "</s>") == ("<s>", "</s>")
+
+    def test_forced_close_suppresses_fail_loud(self):
+        # an explicit close (e.g. HF int decoded to a string) avoids the close raise
+        tpl = "{% set inner_token = x %}{% set outer_token = y %}"
+        assert resolve_think_tokens(tpl, True, None, "</think>") == (None, "</think>")

--- a/tests/test_thinking_format_aggregation.py
+++ b/tests/test_thinking_format_aggregation.py
@@ -1,0 +1,174 @@
+"""Tests for in-repo aggregation of per-response generation info into sample_metrics
+(lm_eval/evaluator_utils.py:promote_generation_info_metrics), which routes the
+thinking-format flags (always) and response/thinking length (opt-in) through the
+standard mean -> consolidate -> W&B path.
+"""
+
+import collections
+from types import SimpleNamespace
+
+from lm_eval.api.metrics import mean
+from lm_eval.evaluator_utils import TaskOutput, promote_generation_info_metrics
+
+
+_doc_counter = iter(range(10_000))
+
+
+def _inst(length_info, repeats=None, doc_id=None):
+    # distinct default doc_id so unrelated fake instances are not grouped together
+    if doc_id is None:
+        doc_id = next(_doc_counter)
+    return SimpleNamespace(length_info=length_info, repeats=repeats, doc_id=doc_id)
+
+
+def _task_output(instances):
+    return SimpleNamespace(
+        task=SimpleNamespace(instances=instances),
+        sample_metrics=collections.defaultdict(list),
+    )
+
+
+def test_promotes_format_flags_to_sample_metrics():
+    to = _task_output(
+        [
+            _inst(
+                [
+                    {
+                        "thinking_format_has_open": 1,
+                        "thinking_format_has_close": 1,
+                        "thinking_format_correct": 1,
+                        "response_length_chars": 42,  # not a format key
+                    }
+                ]
+            ),
+            _inst(
+                [
+                    {
+                        "thinking_format_has_open": 1,
+                        "thinking_format_has_close": 0,
+                        "thinking_format_correct": 0,
+                        "response_length_chars": 10,
+                    }
+                ]
+            ),
+        ]
+    )
+    promote_generation_info_metrics(to)
+    assert to.sample_metrics[("thinking_format_correct", "none")] == [1.0, 0.0]
+    assert to.sample_metrics[("thinking_format_has_open", "none")] == [1.0, 1.0]
+    assert to.sample_metrics[("thinking_format_has_close", "none")] == [1.0, 0.0]
+    # length keys are NOT promoted unless include_length=True
+    assert ("response_length_chars", "none") not in to.sample_metrics
+    # the per-task mean is the format-correctness rate
+    assert mean(to.sample_metrics[("thinking_format_correct", "none")]) == 0.5
+
+
+def test_length_metrics_promoted_only_with_include_length():
+    docs = [
+        _inst(
+            [
+                {
+                    "response_length_chars": 40,
+                    "thinking_length_chars": 10,
+                    "thinking_format_correct": 1,
+                }
+            ]
+        ),
+        _inst(
+            [
+                {
+                    "response_length_chars": 20,
+                    # no thinking_length here (doc didn't reason) -> sparser key
+                    "thinking_format_correct": 0,
+                }
+            ]
+        ),
+    ]
+    # default: length NOT promoted
+    off = _task_output(docs)
+    promote_generation_info_metrics(off, include_length=False)
+    assert ("response_length_chars", "none") not in off.sample_metrics
+    # opt-in: length promoted as a per-task mean; thinking_length only from docs
+    # that produced it (sparser, which the sample_len=max fix tolerates)
+    on = _task_output(docs)
+    promote_generation_info_metrics(on, include_length=True)
+    assert on.sample_metrics[("response_length_chars", "none")] == [40.0, 20.0]
+    assert on.sample_metrics[("thinking_length_chars", "none")] == [10.0]
+    # thinking-format flags still promoted alongside
+    assert on.sample_metrics[("thinking_format_correct", "none")] == [1.0, 0.0]
+
+
+def test_multiple_responses_aggregated_per_doc():
+    # repeats > 1: one length_info dict per response -> ONE per-doc value (the mean),
+    # so the appended count matches num docs (not num responses).
+    to = _task_output(
+        [_inst([{"thinking_format_correct": 1}, {"thinking_format_correct": 0}])]
+    )
+    promote_generation_info_metrics(to)
+    assert to.sample_metrics[("thinking_format_correct", "none")] == [0.5]
+
+
+def test_padding_clones_capped_at_repeats():
+    # data-parallel padding can leave extra length_info entries on the last doc;
+    # only the first `repeats` are real and should count.
+    to = _task_output(
+        [
+            _inst(
+                [
+                    {"thinking_format_correct": 1},
+                    {"thinking_format_correct": 1},  # real (repeats=2)
+                    {"thinking_format_correct": 0},  # padding clone -> ignored
+                ],
+                repeats=2,
+            )
+        ]
+    )
+    promote_generation_info_metrics(to)
+    assert to.sample_metrics[("thinking_format_correct", "none")] == [1.0]
+
+
+def test_multi_turn_instances_grouped_per_doc():
+    # multi_turn_generate produces one Instance per turn; all turns of a doc share
+    # doc_id and must collapse to ONE per-doc value (not one per turn).
+    to = _task_output(
+        [
+            _inst([{"thinking_format_correct": 1}], doc_id=0),  # turn 1
+            _inst([{"thinking_format_correct": 0}], doc_id=0),  # turn 2 (same doc)
+            _inst([{"thinking_format_correct": 1}], doc_id=1),  # other doc
+        ]
+    )
+    promote_generation_info_metrics(to)
+    # doc 0 -> mean(1,0)=0.5 ; doc 1 -> 1.0  => two values, not three
+    assert sorted(to.sample_metrics[("thinking_format_correct", "none")]) == [0.5, 1.0]
+
+
+def test_no_length_info_yields_no_metrics():
+    to = _task_output([_inst([]), _inst(None)])
+    promote_generation_info_metrics(to)
+    assert len(to.sample_metrics) == 0
+
+
+def test_group_placeholder_task_none_is_noop():
+    to = SimpleNamespace(task=None, sample_metrics=collections.defaultdict(list))
+    promote_generation_info_metrics(to)  # must not raise
+    assert len(to.sample_metrics) == 0
+
+
+def test_bool_values_excluded():
+    # bool is an int subclass; flags are emitted as plain ints, so a stray bool
+    # must not be promoted as 0/1.
+    to = _task_output([_inst([{"thinking_format_correct": True}])])
+    promote_generation_info_metrics(to)
+    assert ("thinking_format_correct", "none") not in to.sample_metrics
+
+
+def test_sample_len_is_max_over_sparse_metrics():
+    # A sparse promoted metric (e.g. thinking_length only on docs that reasoned)
+    # must NOT shrink the reported per-task sample count: sample_len = max, not
+    # last-wins. Inserted after the dense metric so a last-wins bug would show.
+    task = SimpleNamespace(aggregation=lambda: {})  # unknown metrics -> mean
+    to = TaskOutput(task=task, task_name="t")
+    to.sample_metrics[("exact_match", "none")] = [1.0, 0.0, 1.0]  # 3 docs (dense)
+    to.sample_metrics[("thinking_length_chars", "none")] = [10.0]  # sparse: 1 doc
+    to.calculate_aggregate_metric(bootstrap_iters=0)
+    assert to.sample_len == 3  # max(3, 1); a last-wins bug would give 1

--- a/tests/test_thinking_format_aggregation.py
+++ b/tests/test_thinking_format_aggregation.py
@@ -78,7 +78,7 @@ def test_length_metrics_promoted_only_with_include_length():
             [
                 {
                     "response_length_chars": 20,
-                    # no thinking_length here (doc didn't reason) -> sparser key
+                    # this doc did not close its thinking block -> no thinking_length
                     "thinking_format_correct": 0,
                 }
             ]
@@ -88,14 +88,49 @@ def test_length_metrics_promoted_only_with_include_length():
     off = _task_output(docs)
     promote_generation_info_metrics(off, include_length=False)
     assert ("response_length_chars", "none") not in off.sample_metrics
-    # opt-in: length promoted as a per-task mean; thinking_length only from docs
-    # that produced it (sparser, which the sample_len=max fix tolerates)
+    # opt-in: length promoted as a per-task mean. thinking_length shares response
+    # length's basis: the unit occurs on at least one response, so the doc without
+    # it counts as 0 (not skipped) -> averaged over the same docs as response length.
     on = _task_output(docs)
     promote_generation_info_metrics(on, include_length=True)
     assert on.sample_metrics[("response_length_chars", "none")] == [40.0, 20.0]
-    assert on.sample_metrics[("thinking_length_chars", "none")] == [10.0]
+    assert on.sample_metrics[("thinking_length_chars", "none")] == [10.0, 0.0]
     # thinking-format flags still promoted alongside
     assert on.sample_metrics[("thinking_format_correct", "none")] == [1.0, 0.0]
+
+
+def test_multi_unit_pairing_independent():
+    # Both unit pairs (chars and tokens) present on one response must be promoted
+    # independently and paired correctly per unit (guards the suffix-keying).
+    to = _task_output(
+        [
+            _inst(
+                [
+                    {
+                        "response_length_chars": 100,
+                        "thinking_length_chars": 90,
+                        "response_length_tokens": 30,
+                        "thinking_length_tokens": 25,
+                    }
+                ]
+            )
+        ]
+    )
+    promote_generation_info_metrics(to, include_length=True)
+    assert to.sample_metrics[("response_length_chars", "none")] == [100.0]
+    assert to.sample_metrics[("thinking_length_chars", "none")] == [90.0]
+    assert to.sample_metrics[("response_length_tokens", "none")] == [30.0]
+    assert to.sample_metrics[("thinking_length_tokens", "none")] == [25.0]
+
+
+def test_bool_excluded_on_length_path():
+    # bool guard must also apply to length values (the pairing reads rval/tval).
+    to = _task_output(
+        [_inst([{"response_length_chars": True, "thinking_length_chars": False}])]
+    )
+    promote_generation_info_metrics(to, include_length=True)
+    assert ("response_length_chars", "none") not in to.sample_metrics
+    assert ("thinking_length_chars", "none") not in to.sample_metrics
 
 
 def test_multiple_responses_aggregated_per_doc():
@@ -160,6 +195,100 @@ def test_bool_values_excluded():
     to = _task_output([_inst([{"thinking_format_correct": True}])])
     promote_generation_info_metrics(to)
     assert ("thinking_format_correct", "none") not in to.sample_metrics
+
+
+def test_thinking_length_shares_response_basis():
+    # Mixed task: some responses close their thinking block, some don't. thinking
+    # length must be averaged over the SAME responses as response length (missing
+    # = 0), so it can never exceed response length. A skip-missing bug would give
+    # mean(thinking) = 90 > mean(response) = 55.
+    docs = [
+        _inst([{"response_length_chars": 100, "thinking_length_chars": 90}]),
+        _inst([{"response_length_chars": 10}]),  # no closed block -> thinking 0
+    ]
+    to = _task_output(docs)
+    promote_generation_info_metrics(to, include_length=True)
+    assert to.sample_metrics[("response_length_chars", "none")] == [100.0, 10.0]
+    assert to.sample_metrics[("thinking_length_chars", "none")] == [90.0, 0.0]
+    assert mean(to.sample_metrics[("thinking_length_chars", "none")]) <= mean(
+        to.sample_metrics[("response_length_chars", "none")]
+    )
+
+
+def test_zero_fill_within_doc_partial_close():
+    # repeats>1: within ONE doc, some responses close their thinking block and some
+    # don't. The non-closing responses count as 0, so the per-doc thinking mean is
+    # over all responses (mean(90, 0) = 45), same basis as response_length.
+    to = _task_output(
+        [
+            _inst(
+                [
+                    {"response_length_chars": 100, "thinking_length_chars": 90},
+                    {"response_length_chars": 100},
+                ],
+                repeats=2,
+            )
+        ]
+    )
+    promote_generation_info_metrics(to, include_length=True)
+    assert to.sample_metrics[("response_length_chars", "none")] == [100.0]
+    assert to.sample_metrics[("thinking_length_chars", "none")] == [45.0]
+
+
+def test_no_thinking_anywhere_zero_thinking_length():
+    # thinking_length_<unit> is paired per-unit with response_length_<unit>: when no
+    # response closed a block it is emitted as 0 for every response that has the
+    # response_length unit (same basis/count, and consistent across ranks so a
+    # multi-GPU shard with no thinking can't desync the key set).
+    docs = [
+        _inst([{"response_length_chars": 30}]),
+        _inst([{"response_length_chars": 40}]),
+    ]
+    to = _task_output(docs)
+    promote_generation_info_metrics(to, include_length=True)
+    assert to.sample_metrics[("response_length_chars", "none")] == [30.0, 40.0]
+    assert to.sample_metrics[("thinking_length_chars", "none")] == [0.0, 0.0]
+
+
+def test_length_less_response_not_counted():
+    # A response dict carrying no response_length_* (e.g. an empty {} from a
+    # suppressed error, or a format-only dict) must contribute to NEITHER response
+    # nor thinking length, so the two stay on an identical count/basis.
+    docs = [
+        _inst([{"response_length_chars": 100, "thinking_length_chars": 90}]),
+        _inst([{"thinking_format_correct": 0}]),  # format-only, no response_length
+        _inst([{}]),  # empty (suppressed-error) dict
+    ]
+    to = _task_output(docs)
+    promote_generation_info_metrics(to, include_length=True)
+    rc = to.sample_metrics[("response_length_chars", "none")]
+    tc = to.sample_metrics[("thinking_length_chars", "none")]
+    assert rc == [100.0]  # only the doc that had response_length
+    assert tc == [90.0]  # same single basis, NOT [90.0, 0.0, 0.0]
+    assert len(rc) == len(tc)
+
+
+def test_orphan_thinking_unit_without_response_dropped():
+    # thinking_length_<unit> with no matching response_length_<unit> (e.g. vLLM
+    # token_ids=None -> no response_length_tokens, but tokenizer set -> a
+    # thinking_length_tokens) is dropped, so it can't exceed / outnumber response.
+    to = _task_output(
+        [
+            _inst(
+                [
+                    {
+                        "response_length_chars": 100,
+                        "thinking_length_chars": 90,
+                        "thinking_length_tokens": 50,  # orphan: no response_length_tokens
+                    }
+                ]
+            )
+        ]
+    )
+    promote_generation_info_metrics(to, include_length=True)
+    assert to.sample_metrics[("thinking_length_chars", "none")] == [90.0]
+    assert ("thinking_length_tokens", "none") not in to.sample_metrics
+    assert ("response_length_tokens", "none") not in to.sample_metrics
 
 
 def test_sample_len_is_max_over_sparse_metrics():

--- a/tests/test_thinking_format_aggregation.py
+++ b/tests/test_thinking_format_aggregation.py
@@ -7,8 +7,16 @@ standard mean -> consolidate -> W&B path.
 import collections
 from types import SimpleNamespace
 
+import pytest
+
+from lm_eval.api.group import ConfigurableGroup
 from lm_eval.api.metrics import mean
-from lm_eval.evaluator_utils import TaskOutput, promote_generation_info_metrics
+from lm_eval.api.task import Task
+from lm_eval.evaluator_utils import (
+    TaskOutput,
+    consolidate_group_results,
+    promote_generation_info_metrics,
+)
 
 
 _doc_counter = iter(range(10_000))
@@ -191,7 +199,9 @@ def test_multi_turn_length_only_well_formed_turns_count():
         ]
     )
     promote_generation_info_metrics(to, include_length=True)
-    assert to.sample_metrics[("response_length_chars", "none")] == [70.0]  # mean(100,40)
+    assert to.sample_metrics[("response_length_chars", "none")] == [
+        70.0
+    ]  # mean(100,40)
     assert to.sample_metrics[("thinking_length_chars", "none")] == [80.0]  # turn 1 only
 
 
@@ -293,3 +303,89 @@ def test_sample_len_is_max_over_sparse_metrics():
     to.sample_metrics[("thinking_length_chars", "none")] = [10.0]  # sparse: 1 doc
     to.calculate_aggregate_metric(bootstrap_iters=0)
     assert to.sample_len == 3  # max(3, 1); a last-wins bug would give 1
+
+
+class _StubTask(Task):
+    """Minimal concrete Task: `consolidate_group_results` only reads `.task_name`."""
+
+    def __init__(self, name):
+        self.task_name = name
+
+    def has_training_docs(self): ...
+    def has_validation_docs(self): ...
+    def has_test_docs(self): ...
+    def doc_to_text(self, doc): ...
+    def doc_to_target(self, doc): ...
+    def construct_requests(self, doc, ctx, **kw): ...
+    def process_results(self, doc, results): ...
+    def aggregation(self): ...
+    def higher_is_better(self): ...
+
+
+def test_group_samples_independent_of_metric_iteration_order(monkeypatch):
+    """A group's `samples` is the sum over its subtasks, whatever metric is last.
+
+    `metric_list` is built from a *set*, so its order varies per process. The group's
+    `sizes` are filtered to the subtasks carrying that one metric, so assigning
+    `samples` inside the per-metric loop undercounted whenever a SPARSE metric (e.g. a
+    promoted `thinking_format_*`, present on only some subtasks) landed last. `samples`
+    is published in results.json and reused as the pooling weight by any parent group.
+    """
+    import lm_eval.evaluator_utils as eu
+
+    def build():
+        results = collections.defaultdict(dict)
+        results["taskA"] = {  # dense only
+            "alias": "taskA",
+            "exact_match,none": 0.5,
+            "exact_match_stderr,none": 0.1,
+            "samples": 100,
+        }
+        results["taskB"] = {  # dense + sparse promoted metric
+            "alias": "taskB",
+            "exact_match,none": 0.3,
+            "exact_match_stderr,none": 0.1,
+            "thinking_format_correct,none": 0.9,
+            "thinking_format_correct_stderr,none": 0.01,
+            "samples": 50,
+        }
+        group = ConfigurableGroup(
+            config={
+                "group": "mygroup",
+                "task": ["taskA", "taskB"],
+                "aggregate_metric_list": [
+                    {
+                        "metric": "exact_match",
+                        "aggregation": "mean",
+                        "weight_by_size": True,
+                        "filter_list": ["none"],
+                    }
+                ],
+            }
+        )
+        return results, {
+            group: {"taskA": _StubTask("taskA"), "taskB": _StubTask("taskB")}
+        }
+
+    builtin_list = list
+    for order in (
+        ["thinking_format_correct,none", "exact_match,none"],  # dense last
+        ["exact_match,none", "thinking_format_correct,none"],  # SPARSE last (the bug)
+    ):
+        monkeypatch.setattr(
+            eu,
+            "list",
+            lambda x, _o=order: _o if isinstance(x, set) else builtin_list(x),
+            raising=False,
+        )
+        results, task_dict = build()
+        res, *_ = consolidate_group_results(
+            results, collections.defaultdict(dict), task_dict
+        )
+        assert res["mygroup"]["samples"] == 150, (
+            f"order={order}: got {res['mygroup']['samples']}, expected 100+50"
+        )
+        # the group's own weighted metric was always right; only `samples` was wrong
+        assert res["mygroup"]["exact_match,none"] == pytest.approx(
+            (0.5 * 100 + 0.3 * 50) / 150
+        )

--- a/tests/test_thinking_format_aggregation.py
+++ b/tests/test_thinking_format_aggregation.py
@@ -88,20 +88,20 @@ def test_length_metrics_promoted_only_with_include_length():
     off = _task_output(docs)
     promote_generation_info_metrics(off, include_length=False)
     assert ("response_length_chars", "none") not in off.sample_metrics
-    # opt-in: length promoted as a per-task mean. thinking_length shares response
-    # length's basis: the unit occurs on at least one response, so the doc without
-    # it counts as 0 (not skipped) -> averaged over the same docs as response length.
+    # opt-in: response_length over ALL responses; thinking_length only over the
+    # responses that carry it (the well-formed ones; the malformed doc is absent, NOT
+    # zero-filled).
     on = _task_output(docs)
     promote_generation_info_metrics(on, include_length=True)
     assert on.sample_metrics[("response_length_chars", "none")] == [40.0, 20.0]
-    assert on.sample_metrics[("thinking_length_chars", "none")] == [10.0, 0.0]
-    # thinking-format flags still promoted alongside
+    assert on.sample_metrics[("thinking_length_chars", "none")] == [10.0]
+    # thinking-format flags still promoted alongside, over all responses
     assert on.sample_metrics[("thinking_format_correct", "none")] == [1.0, 0.0]
 
 
-def test_multi_unit_pairing_independent():
-    # Both unit pairs (chars and tokens) present on one response must be promoted
-    # independently and paired correctly per unit (guards the suffix-keying).
+def test_multi_unit_promoted_independently():
+    # Each unit (chars, tokens) for both response and thinking length is promoted as
+    # its own independent key.
     to = _task_output(
         [
             _inst(
@@ -124,7 +124,7 @@ def test_multi_unit_pairing_independent():
 
 
 def test_bool_excluded_on_length_path():
-    # bool guard must also apply to length values (the pairing reads rval/tval).
+    # bool guard (int subclass) must also apply to length values.
     to = _task_output(
         [_inst([{"response_length_chars": True, "thinking_length_chars": False}])]
     )
@@ -177,6 +177,24 @@ def test_multi_turn_instances_grouped_per_doc():
     assert sorted(to.sample_metrics[("thinking_format_correct", "none")]) == [0.5, 1.0]
 
 
+def test_multi_turn_length_only_well_formed_turns_count():
+    # multi_turn_generate: each turn is a SEPARATE Instance sharing doc_id. Turn 1 is
+    # well-formed (carries thinking_length); turn 2 is not (response only). The per-doc
+    # response length averages BOTH turns; thinking length counts ONLY the well-formed
+    # turn (denominator = correct turns, no zero-fill from the malformed one).
+    to = _task_output(
+        [
+            _inst(
+                [{"response_length_chars": 100, "thinking_length_chars": 80}], doc_id=0
+            ),  # turn 1, well-formed
+            _inst([{"response_length_chars": 40}], doc_id=0),  # turn 2, not well-formed
+        ]
+    )
+    promote_generation_info_metrics(to, include_length=True)
+    assert to.sample_metrics[("response_length_chars", "none")] == [70.0]  # mean(100,40)
+    assert to.sample_metrics[("thinking_length_chars", "none")] == [80.0]  # turn 1 only
+
+
 def test_no_length_info_yields_no_metrics():
     to = _task_output([_inst([]), _inst(None)])
     promote_generation_info_metrics(to)
@@ -197,49 +215,41 @@ def test_bool_values_excluded():
     assert ("thinking_format_correct", "none") not in to.sample_metrics
 
 
-def test_thinking_length_shares_response_basis():
-    # Mixed task: some responses close their thinking block, some don't. thinking
-    # length must be averaged over the SAME responses as response length (missing
-    # = 0), so it can never exceed response length. A skip-missing bug would give
-    # mean(thinking) = 90 > mean(response) = 55.
+def test_thinking_length_denominator_excludes_incorrect():
+    # Unbiased average: thinking_length is present only on well-formed responses, so
+    # its mean's denominator is the count of CORRECT responses — never inflated by the
+    # malformed one. response_length stays over all responses.
     docs = [
-        _inst([{"response_length_chars": 100, "thinking_length_chars": 90}]),
-        _inst([{"response_length_chars": 10}]),  # no closed block -> thinking 0
+        _inst([{"response_length_chars": 100, "thinking_length_chars": 80}]),  # correct
+        _inst([{"response_length_chars": 120, "thinking_length_chars": 90}]),  # correct
+        _inst([{"response_length_chars": 10}]),  # malformed -> no thinking_length
     ]
     to = _task_output(docs)
     promote_generation_info_metrics(to, include_length=True)
-    assert to.sample_metrics[("response_length_chars", "none")] == [100.0, 10.0]
-    assert to.sample_metrics[("thinking_length_chars", "none")] == [90.0, 0.0]
-    assert mean(to.sample_metrics[("thinking_length_chars", "none")]) <= mean(
-        to.sample_metrics[("response_length_chars", "none")]
-    )
+    assert to.sample_metrics[("response_length_chars", "none")] == [100.0, 120.0, 10.0]
+    # thinking over the 2 correct only -> mean(80,90)=85, NOT divided by 3
+    assert to.sample_metrics[("thinking_length_chars", "none")] == [80.0, 90.0]
+    assert mean(to.sample_metrics[("thinking_length_chars", "none")]) == 85.0
 
 
-def test_zero_fill_within_doc_partial_close():
-    # repeats>1: within ONE doc, some responses close their thinking block and some
-    # don't. The non-closing responses count as 0, so the per-doc thinking mean is
-    # over all responses (mean(90, 0) = 45), same basis as response_length.
-    to = _task_output(
-        [
-            _inst(
-                [
-                    {"response_length_chars": 100, "thinking_length_chars": 90},
-                    {"response_length_chars": 100},
-                ],
-                repeats=2,
-            )
-        ]
-    )
+def test_aggregate_thinking_may_exceed_aggregate_response():
+    # Intended consequence of "response over all, thinking over correct-only": the
+    # aggregate thinking mean can exceed the aggregate response mean (different bases),
+    # even though per-sample thinking <= response always holds.
+    docs = [
+        _inst([{"response_length_chars": 100, "thinking_length_chars": 90}]),  # correct
+        _inst([{"response_length_chars": 10}]),  # malformed -> no thinking_length
+    ]
+    to = _task_output(docs)
     promote_generation_info_metrics(to, include_length=True)
-    assert to.sample_metrics[("response_length_chars", "none")] == [100.0]
-    assert to.sample_metrics[("thinking_length_chars", "none")] == [45.0]
+    assert mean(to.sample_metrics[("response_length_chars", "none")]) == 55.0
+    assert mean(to.sample_metrics[("thinking_length_chars", "none")]) == 90.0
 
 
-def test_no_thinking_anywhere_zero_thinking_length():
-    # thinking_length_<unit> is paired per-unit with response_length_<unit>: when no
-    # response closed a block it is emitted as 0 for every response that has the
-    # response_length unit (same basis/count, and consistent across ranks so a
-    # multi-GPU shard with no thinking can't desync the key set).
+def test_no_correct_response_omits_thinking_length():
+    # When no response is well-formed, thinking_length has no values and the key is
+    # simply absent (the gather unions keys, so this is multi-rank safe). response
+    # length is still aggregated over all responses.
     docs = [
         _inst([{"response_length_chars": 30}]),
         _inst([{"response_length_chars": 40}]),
@@ -247,31 +257,13 @@ def test_no_thinking_anywhere_zero_thinking_length():
     to = _task_output(docs)
     promote_generation_info_metrics(to, include_length=True)
     assert to.sample_metrics[("response_length_chars", "none")] == [30.0, 40.0]
-    assert to.sample_metrics[("thinking_length_chars", "none")] == [0.0, 0.0]
+    assert ("thinking_length_chars", "none") not in to.sample_metrics
 
 
-def test_length_less_response_not_counted():
-    # A response dict carrying no response_length_* (e.g. an empty {} from a
-    # suppressed error, or a format-only dict) must contribute to NEITHER response
-    # nor thinking length, so the two stay on an identical count/basis.
-    docs = [
-        _inst([{"response_length_chars": 100, "thinking_length_chars": 90}]),
-        _inst([{"thinking_format_correct": 0}]),  # format-only, no response_length
-        _inst([{}]),  # empty (suppressed-error) dict
-    ]
-    to = _task_output(docs)
-    promote_generation_info_metrics(to, include_length=True)
-    rc = to.sample_metrics[("response_length_chars", "none")]
-    tc = to.sample_metrics[("thinking_length_chars", "none")]
-    assert rc == [100.0]  # only the doc that had response_length
-    assert tc == [90.0]  # same single basis, NOT [90.0, 0.0, 0.0]
-    assert len(rc) == len(tc)
-
-
-def test_orphan_thinking_unit_without_response_dropped():
-    # thinking_length_<unit> with no matching response_length_<unit> (e.g. vLLM
-    # token_ids=None -> no response_length_tokens, but tokenizer set -> a
-    # thinking_length_tokens) is dropped, so it can't exceed / outnumber response.
+def test_orphan_thinking_unit_promoted_independently():
+    # Each length key is now independent: a thinking_length_<unit> with no matching
+    # response_length_<unit> (e.g. vLLM token_ids=None -> no response_length_tokens but
+    # a tokenizer-derived thinking_length_tokens) is promoted on its own.
     to = _task_output(
         [
             _inst(
@@ -279,7 +271,7 @@ def test_orphan_thinking_unit_without_response_dropped():
                     {
                         "response_length_chars": 100,
                         "thinking_length_chars": 90,
-                        "thinking_length_tokens": 50,  # orphan: no response_length_tokens
+                        "thinking_length_tokens": 50,  # no response_length_tokens
                     }
                 ]
             )
@@ -287,7 +279,7 @@ def test_orphan_thinking_unit_without_response_dropped():
     )
     promote_generation_info_metrics(to, include_length=True)
     assert to.sample_metrics[("thinking_length_chars", "none")] == [90.0]
-    assert ("thinking_length_tokens", "none") not in to.sample_metrics
+    assert to.sample_metrics[("thinking_length_tokens", "none")] == [50.0]
     assert ("response_length_tokens", "none") not in to.sample_metrics
 
 


### PR DESCRIPTION
# Response/thinking length & thinking-format metrics

> **Update log** — description synced to the latest code: `enable_thinking` clarified as a chat-template argument only (metric tracking keys off the resolved close token, not on thinking on/off); auto-detection noted as opt-in (`autodetect_think_tokens`, default off); caching caveat corrected to `use_cache` (not `--cache_requests`); added the `autodetect_think_tokens` / `track_thinking_metrics` model args, the group-`samples` fix, and `tests/models/test_huggingface.py`.

_Part of the thinking evals integration for post-train evals._

Especially for thinking models, the length of answers and thinking traces is vital as a model should be efficient in its performance to token ratio ideally.

This PR adds tracking of:

1) length of overall response and thinking trace in chars, words and tokens
2) ratio of correctly formatted thinking trace (opens, closes, both in correct order)

## Overview
Measures, per response, **how much reasoning models generate** and **whether their
reasoning is well-formed** on `generate_until` / `multi_turn_generate` tasks
(`hf`, `vllm`, `sglang`). Measured on the **generation before the reasoning strip**
(on `hf`, a view bounded to the response), logged per-sample, and optionally aggregated
per-task into `results.json`, the table, and W&B (no external post-processing). Off by
default; full reference in [`docs/thinking_evals.md`](docs/thinking_evals.md).

| File(s) | Change |
|---|---|
| `lm_eval/api/instance.py` | Add per-response `length_info` field. |
| `lm_eval/models/utils.py` | Compute length (gated by `measure_thinking`) + current-turn thinking-format; shared `build_length_info`; detect/resolve open & close tokens + `detect_open_prefilled`; fail-loud. |
| `lm_eval/models/{huggingface,vllm_causallms,sglang_causallms}.py` | `think_start_token` arg; resolve tokens; `think_open_prefilled` + `track_thinking_metrics`; record format-then-length (thinking only when `correct`) into `length_info`. |
| `lm_eval/evaluator.py` | Log `length_info` per sample; `--log_length_metrics` wiring; call aggregation. |
| `lm_eval/evaluator_utils.py` | `promote_generation_info_metrics` (per-doc aggregation; `thinking_length` over well-formed responses only); fix `sample_len` to `max` and group `samples` to the sum of subtask samples. |
| `lm_eval/_cli/run.py`, `lm_eval/config/evaluate_config.py` | `--log_length_metrics` flag. |
| `lm_eval/loggers/wandb_logger.py` | Fix W&B samples table crashing on `!function` metrics (e.g. humaneval). |
| `tests/models/{test_model_utils,test_huggingface}.py`, `tests/test_thinking_format_aggregation.py` | Unit tests (helpers + HF int-mode / batch-overflow bounding; aggregation). |
| `docs/thinking_evals.md` (new), `docs/interface.md`, `docs/README.md`, `README.md` | Docs. |

## What's added
- **Length** (per response): `response_length_{words,chars,tokens}` (always);
  `thinking_length_{words,chars,tokens}` (reasoning span up to & incl. the **last**
  close token — the strip boundary), recorded **only for well-formed responses**.
- **Thinking-format** (per response, 0/1, **current-turn only**):
  `thinking_format_has_open`, `thinking_format_has_close`, `thinking_format_correct`
  (open present *this turn* & close present, open before close, not re-opened;
  **close-only models** → `correct = has_close`).
- **Tokens**: set explicitly via `think_start_token` / `think_end_token`, or
  auto-detected from the chat template (`inner_token`/`outer_token`) when opted in via
  `autodetect_think_tokens` (**default off** — a bare run resolves no close, so no strip
  and no thinking metrics). The close drives the reasoning strip. **Fail-loud** if
  auto-detect is on and the template declares reasoning tokens but the close can't be parsed.
- **Native aggregation**: calculate per-doc means via the standard
  gather → `consolidate_results` → W&B path; grouped by `doc_id` (multi-turn
  aggregates per doc, not per turn). `response_length` averages over **all** responses;
  `thinking_length` over **well-formed (`correct = 1`) responses only** (unbiased).
- **Fix**: W&B per-sample table no longer crashes on `!function` metrics.

## Flags
| Sink | Flag | Length | Format |
|---|---|---|---|
| Per-sample (`length_info` in `samples_*.jsonl`) | `--log_samples` | yes | yes |
| Per-task (`results.json` + table) | `--log_length_metrics` (length only) | flag | always* |
| W&B (native) | `--wandb_args` | flag | always* |

\*when the token resolved. Aggregated keys use the `none` filter:
`results.json` → `…_correct,none`; W&B drops it → `gsm8k/thinking_format_correct`.
Model args: `think_start_token`, `think_end_token`, `autodetect_think_tokens`,
`track_thinking_metrics`; plus `enable_thinking` on `hf` / `vllm` (`sglang`'s template decides).

## Counting & aggregation
`response_length_*` and `thinking_length_*` average over **different bases**:
`response_length` over **all** responses; `thinking_length` over **well-formed
responses only** (`thinking_format_correct = 1`), so malformed responses are excluded
from its denominator (unbiased — no zero-fill). `thinking_format_*` are rates over
**all** responses. Per-sample `thinking ≤ response` always holds; the **aggregate**
thinking mean is *not* bounded by the aggregate response mean (different bases).

- **No thinking / unclosed block** (`correct = 0`) → no `thinking_length` recorded
  (excluded from its average); `response_length` still counts it; reasoning is **not**
  stripped (no close), so it stays in the scored text → task score may ↓. More
  malformed ⇒ `has_close`/`correct` ↓ (the signal you want), `response_length`
  unchanged, `thinking_length` stays **unbiased** (not deflated).
- **Correctness is current-turn only** → the open is searched in the model's
  generation (or a prefill template's own generation-prompt open), **never the rendered
  history**, so a prior turn's unclosed open (multi-turn) or few-shot demo tags can't
  inflate `has_open`/`correct` — correct for **prefill and non-prefill** models alike.
- **Close-only models** (no open token) → `correct = has_close`; `thinking_length`
  counts the closed responses.
- **Multi-turn** → strip + measurement **per turn**, averaged per `doc_id` (a K-turn
  doc = one per-doc value, not K). **No cross-turn stitching**: an open-no-close turn
  and the later closing turn are both `correct = 0`, so neither contributes a
  (mis-attributed) `thinking_length`.
- **`enable_thinking`** is a chat-template argument only (whether the model reasons),
  not a metric switch — tracking keys off the **resolved close token**. Thinking off but
  a close known ⇒ `thinking_format_*` still emit (as ≈0 rates) and `thinking_length_*`
  drops out (no `correct = 1`); no close resolved ⇒ only `response_length_*`. Force the
  thinking metrics on/off with `track_thinking_metrics`.
- **No token count from backend** → that `_tokens` unit is dropped (smaller base
  than `_words`/`_chars`).

## Validation
- Unit tests (helpers incl. `build_length_info` / current-turn open / prefill
  detection / close-only `correct` / last-close boundary, token resolve/fail-loud,
  per-doc aggregation with unbiased thinking-length denominator).
- End-to-end on Apertus-1.5-8B (latest code): **vLLM and HF** (HF incl. forced int
  `think_end_token`), single-turn `gsm8k` and genuine **K=2 multi-turn**
  `realguardrails_s_rules_basic_helpful`, single- and multi-rank, think/nothink —
  every value aggregate reconciles exactly to a per-doc recompute and uploads to W&B,
  correctly gated (0 W&B failures); `response_length` over all vs `thinking_length`
  over `correct=1` confirmed, with **0** history-leak and **0** per-sample
  `thinking > response`.

## Notes
- Auto-detect (opt-in) uses the template's declared tokens; if a model emits a different
  close than its template declares, pass `think_end_token=` explicitly.
- `thinking_format_*` only appears once a close token is resolved.
- Metrics are measured during generation, so responses served from the `use_cache`
  response cache (`CachingLM`, which skips generation) carry no `length_info`
  (`--cache_requests` only caches request building, so it is unaffected).

