### PR TITLE
Refactor import of resolve_hf_chat_template - support for updated VLLM

### DIFF
--- a/lm_eval/models/vllm_causallms.py
+++ b/lm_eval/models/vllm_causallms.py
@@ -42,7 +42,11 @@ from lm_eval.utils import (
 
 
 if parse_version(version("vllm")) >= parse_version("0.8.3"):
-    from vllm.entrypoints.chat_utils import resolve_hf_chat_template
+    try:
+        # Moved since vllm-project/vllm#30200
+        from vllm.renderers.hf import resolve_chat_template as resolve_hf_chat_template
+    except ImportError:
+        from vllm.entrypoints.chat_utils import resolve_hf_chat_template
 
 try:
     # Moved since vllm-project/vllm#29793


### PR DESCRIPTION
Necessary fix for newer VLLM versions (see following issue: https://github.com/EleutherAI/lm-evaluation-harness/pull/3595)