### PR TITLE
Use namespaced facebook/xnli dataset id

### DIFF
--- a/lm_eval/tasks/spanish_bench/xnli_es_spanish_bench.yaml
+++ b/lm_eval/tasks/spanish_bench/xnli_es_spanish_bench.yaml
@@ -1,6 +1,6 @@
 # Task configuration derived from Eleuther AI's implementation as of March 22, 2024, supplemented with an additional preprocessing function
 task: xnli_es_spanish_bench
-dataset_path: xnli
+dataset_path: facebook/xnli
 dataset_name: es
 output_type: multiple_choice
 doc_to_choice: '{{[premise+", ¿correcto? Sí, "+hypothesis,premise+", ¿correcto? Así

--- a/lm_eval/tasks/xnli/xnli_common_yaml
+++ b/lm_eval/tasks/xnli/xnli_common_yaml
@@ -2,7 +2,7 @@
 # It doesn't have a yaml file extension as it is not meant to be imported directly
 # by the harness.
 task: null
-dataset_path: xnli
+dataset_path: facebook/xnli
 dataset_name: null
 output_type: multiple_choice
 training_split: train

--- a/lm_eval/tasks/xnli_eu/xnli_common_yaml
+++ b/lm_eval/tasks/xnli_eu/xnli_common_yaml
@@ -1,5 +1,5 @@
 task: null
-dataset_path: xnli
+dataset_path: facebook/xnli
 dataset_name: null
 output_type: multiple_choice
 training_split: train


### PR DESCRIPTION
Canonical (un-namespaced) dataset ids are rejected by `huggingface_hub` >= 1.2x strict HF-URI parsing:

```
huggingface_hub.errors.HfUriError: Invalid HF URI 'hf://datasets/xnli@.../.huggingface.yaml'. Repository id must be 'namespace/name', got 'xnli'.
```

This kills any run that needs to fetch xnli uncached (hit in the swiss-ai/evals-post-train posttrain suite). `facebook/xnli` is the canonical dataset's namespaced home — verified it resolves with huggingface-hub 1.24 + datasets 5.0.

Same fix applied to the `spanish_bench` and `xnli_eu` variants that share the id.

🤖 Generated with [Claude Code](https://claude.com/claude-code)