### PR TITLE
`xcopa` fails to load with huggingface_hub >= 1.3 (non-namespaced `dataset_path`)

### DIFF
--- a/lm_eval/tasks/xcopa/default_et.yaml
+++ b/lm_eval/tasks/xcopa/default_et.yaml
@@ -1,5 +1,5 @@
 task: xcopa_et
-dataset_path: xcopa
+dataset_path: cambridgeltl/xcopa
 dataset_name: et
 output_type: multiple_choice
 validation_split: validation


### PR DESCRIPTION
### Summary

Every `xcopa` subtask fails at task-registration time (before any generation)  with:

```
huggingface_hub.errors.HfUriError: Invalid HF URI
'hf://datasets/xcopa@.../.huggingface.yaml'.
Repository id must be 'namespace/name', got 'xcopa'
```

### Cause

`lm_eval/tasks/xcopa/*.yaml` pins `dataset_path: xcopa`, the dataset's legacy pre-namespace ID.
Current `huggingface_hub` requires all repo IDs to be `namespace/name` and rejects the bare form
outright.

### Suggested fix

Repoint `dataset_path` at the namespaced ID (or a namespaced mirror). This has appeared before in the repository: the equivalent fix for `xnli` was merged as `fix/xnli-namespaced-dataset` (commit `b403756e`), so the same treatment should apply cleanly here.

### Environment

- lm-evaluation-harness `b403756e` (main)
- huggingface_hub >= 1.3