### PR TITLE
Fix vLLM backend crash with data_parallel_size > 1

### DIFF
--- a/lm_eval/models/vllm_causallms.py
+++ b/lm_eval/models/vllm_causallms.py
@@ -205,6 +205,15 @@ class VLLM(TemplateLM):
         # truncation strategy for inputs exceeding max length
         self.truncation_side = truncation_side
         self.data_parallel_size = int(data_parallel_size)
+        if swap_space != 4:
+            # vLLM no longer accepts swap_space as a constructor argument (matches the
+            # resolution EleutherAI/lm-evaluation-harness applied upstream for the same
+            # deprecation). Only warn when a caller actually asked for a non-default value,
+            # since swap_space keeps its old default here and is otherwise always "set".
+            eval_logger.warning(
+                "swap_space is no longer supported by vLLM; ignoring the requested "
+                f"value ({swap_space})."
+            )
         if disable_flashinfer_allreduce_fusion:
             # Avoid FlashInfer's fused all-reduce/RMS workspace while retaining
             # vLLM's ordinary all-reduce and the rest of torch.compile.
@@ -225,7 +234,6 @@ class VLLM(TemplateLM):
             "tensor_parallel_size": int(tensor_parallel_size),
             "max_model_len": int(self._max_length) if self._max_length else None,
             "max_num_seqs": kwargs.get("max_num_seqs", max_batch_size),
-            "swap_space": int(swap_space),
             "quantization": quantization,
             "seed": int(seed),
             "enable_lora": bool(lora_local_path),


### PR DESCRIPTION
## Problem

Any run with `data_parallel_size > 1` on the vLLM backend dies during construction, before any prompt is processed:

```
TypeError: EngineArgs.__init__() got an unexpected keyword argument 'swap_space'
```

## Root cause

In `lm_eval/models/vllm_causallms.py`:

1. `__init__` builds `self.model_args` and unconditionally includes  `"swap_space": int(swap_space)` - a valid argument to vLLM's `LLM(...)`.
2. With `data_parallel_size <= 1` the wrapper instantiates the engine once: `self.model = LLM(**self.model_args)`. `LLM` accepts `swap_space`. Fine.
3. With `data_parallel_size > 1` that call is skipped - replicas are created later, per worker, inside a `@ray.remote` function. So at construction time there is no `self.model`, and therefore no `self.model.llm_engine.model_config`.
4. Resolving the HF chat template needs a `model_config`. With DP <= 1 it's read off the live engine; with DP > 1 there is no engine, so the code reconstructs one:

   ```python
   from vllm.engine.arg_utils import EngineArgs
   engine_args = EngineArgs(**self.model_args)   # dies here
   ```

5. `EngineArgs` is a dataclass of engine fields and, in the pinned vLLM version, has no `swap_space` field - it moved to CacheConfig`/`LLM`. Passing an `LLM`-shaped kwargs dict therefore raises.

So this isn't "DP is broken" in general - the DP > 1 path reuses a kwargs dict built for `LLM` to construct an `EngineArgs`, and the two accept different fields.

## Fix

Do not forward `swap_space` into `self.model_args`, so the same dict works for both `LLM(**model_args)` and `EngineArgs(**model_args)`. `swap_space` stays in the public `__init__` signature (default `4`). A caller that explicitly overrides the default now gets a warning explaining it is ignored, instead of a silent no-op or, under DP>1, a crash.

This matches the resolution `EleutherAI/lm-evaluation-harness` already applied upstream for the same vLLM deprecation - their `vllm_causallms.py` drops `swap_space` from `kwargs` with an equivalent warning before it reaches vLLM. This fork's copy of the file has since diverged substantially, so rather than porting that diff, only the fix is applied at the equivalent point in the current structure.

## Testing

Verified directly against the installed vLLM's `EngineArgs`:

```python
from vllm.engine.arg_utils import EngineArgs
EngineArgs(model="gpt2", swap_space=4)   # raises TypeError: unexpected keyword argument 'swap_space'
EngineArgs(model="gpt2")                 # succeeds
```

vLLM version: 0.22.1.