### PR TITLE
Fix answer extraction in hendrycks_math and minerva_math

### DIFF
--- a/lm_eval/tasks/hendrycks_math/utils.py
+++ b/lm_eval/tasks/hendrycks_math/utils.py
@@ -209,15 +209,29 @@ def is_equiv(x1: str, x2: str) -> bool:
 def get_unnormalized_answer(text: str) -> str:
     INVALID_ANSWER = "[invalidanswer]"
     end_seq = "I hope it is correct."
-    text += end_seq
     match = re.search(
         r"Final Answer: The final answer is(.*?). I hope it is correct.",
-        text,
+        # NB: end_seq is appended with a separating space. Concatenating it directly
+        # produces "...is 7.I hope it is correct.", and the pattern requires ". I hope",
+        # so the patch-up never fired for text ending on a bare period.
+        text + " " + end_seq,
     )
     if match:
         return match.group(1).strip()
-    else:
-        return INVALID_ANSWER
+
+    # Fall back to the model's own \boxed{...} (as used for the gold solution
+    # above): the few-shot examples in list_fewshot_samples() end each solution
+    # right after "Final Answer: The final answer is $X$." without the phrase, so
+    # a model mirroring that style may omit it entirely and the regex above never
+    # matches, even when $X$ is correct.
+    boxed = last_boxed_only_string(text)
+    if boxed is not None:
+        try:
+            return remove_boxed(boxed)
+        except (AssertionError, IndexError):
+            pass
+
+    return INVALID_ANSWER
 
 
 SUBSTITUTIONS = [

--- a/lm_eval/tasks/hendrycks_math/utils.py
+++ b/lm_eval/tasks/hendrycks_math/utils.py
@@ -2,7 +2,7 @@ import logging
 import re
 import signal
 from importlib.metadata import version
-from typing import Dict, List, Optional
+from importlib.util import find_spec
 
 import datasets
 
@@ -11,11 +11,12 @@ eval_logger = logging.getLogger(__name__)
 
 
 try:
-    import antlr4
     import sympy
     from math_verify import parse, verify
     from sympy.parsing.latex import parse_latex
 
+    if find_spec("antlr4") is None:
+        raise ModuleNotFoundError("No module named 'antlr4'")
     assert version("antlr4-python3-runtime").startswith("4.11")
 except (ModuleNotFoundError, AssertionError) as e:
     raise type(e)(
@@ -69,28 +70,25 @@ def list_fewshot_samples() -> list[dict]:
             "few_shot": "1",
         },
         {
-            "problem": "One sphere is centered at $(3,-5,7)$ with radius $5 \sqrt{5}.$ A second sphere is centered at $(0,1,1)$ with radius $2 \sqrt{17}.$ The two spheres intersect in a circle. Find the radius of this circle.",
-            "solution": 'Let $A = (3,-5,7),$ the center of the first sphere, and let $B = (0,1,1),$ the center of the second sphere. We can compute that $AB = 9.$ Let $C$ be a point on the intersection of both spheres, so $AC = 5 \sqrt{5}$ and $BC = 2 \sqrt{17}.$ [asy] unitsize(0.3 cm);\n\npair A, B, C;\n\nA = (0,0);\nB = (9,0);\nC = intersectionpoint(arc(A,5*sqrt(5),0,180),arc(B,2*sqrt(17),0,180));\n\ndraw(A--B--C--cycle);\ndraw(Circle(A,5*sqrt(5)));\ndraw(Circle(B,2*sqrt(17)));\n\nlabel("$A$", A, W);\nlabel("$B$", B, S);\nlabel("$C$", C, N);\nlabel("$9$", (A + B)/2, S, red);\nlabel("$5 \\sqrt{5}$", (A + C)/2, NW, red, UnFill);\nlabel("$2 \\sqrt{17}$", (B + C)/2, E, red, UnFill);\n[/asy]\n\nBy Heron\'s formula, we can compute that $[ABC] = 3 \\sqrt{149}.$\n\nLet $D$ be the foot of the perpendicular from $C$ to $\\overline{AB}.$\n\n[asy]\nunitsize(0.3 cm);\n\npair A, B, C, D;\n\nA = (0,0);\nB = (9,0);\nC = intersectionpoint(arc(A,5*sqrt(5),0,180),arc(B,2*sqrt(17),0,180));\nD = (C.x,0);\n\ndraw(A--B--C--cycle);\ndraw(C--D);\n\nlabel("$A$", A, W);\nlabel("$B$", B, S);\nlabel("$C$", C, N);\nlabel("$D$", D, S);\n[/asy]\n\nThen the intersection of both spheres is the circle centered at $D$ with radius $CD.$ Thus,\n\\[CD = \\frac{2 [ABC]}{AB} = \\frac{6 \\sqrt{149}}{9} = \\boxed{\\frac{2 \\sqrt{149}}{3}}.\\] \nFinal Answer: The final answer is $\\frac{2 \\sqrt{149}}{3}$.',
+            "problem": "One sphere is centered at $(3,-5,7)$ with radius $5 \\sqrt{5}.$ A second sphere is centered at $(0,1,1)$ with radius $2 \\sqrt{17}.$ The two spheres intersect in a circle. Find the radius of this circle.",
+            "solution": 'Let $A = (3,-5,7),$ the center of the first sphere, and let $B = (0,1,1),$ the center of the second sphere. We can compute that $AB = 9.$ Let $C$ be a point on the intersection of both spheres, so $AC = 5 \\sqrt{5}$ and $BC = 2 \\sqrt{17}.$ [asy] unitsize(0.3 cm);\n\npair A, B, C;\n\nA = (0,0);\nB = (9,0);\nC = intersectionpoint(arc(A,5*sqrt(5),0,180),arc(B,2*sqrt(17),0,180));\n\ndraw(A--B--C--cycle);\ndraw(Circle(A,5*sqrt(5)));\ndraw(Circle(B,2*sqrt(17)));\n\nlabel("$A$", A, W);\nlabel("$B$", B, S);\nlabel("$C$", C, N);\nlabel("$9$", (A + B)/2, S, red);\nlabel("$5 \\sqrt{5}$", (A + C)/2, NW, red, UnFill);\nlabel("$2 \\sqrt{17}$", (B + C)/2, E, red, UnFill);\n[/asy]\n\nBy Heron\'s formula, we can compute that $[ABC] = 3 \\sqrt{149}.$\n\nLet $D$ be the foot of the perpendicular from $C$ to $\\overline{AB}.$\n\n[asy]\nunitsize(0.3 cm);\n\npair A, B, C, D;\n\nA = (0,0);\nB = (9,0);\nC = intersectionpoint(arc(A,5*sqrt(5),0,180),arc(B,2*sqrt(17),0,180));\nD = (C.x,0);\n\ndraw(A--B--C--cycle);\ndraw(C--D);\n\nlabel("$A$", A, W);\nlabel("$B$", B, S);\nlabel("$C$", C, N);\nlabel("$D$", D, S);\n[/asy]\n\nThen the intersection of both spheres is the circle centered at $D$ with radius $CD.$ Thus,\n\\[CD = \\frac{2 [ABC]}{AB} = \\frac{6 \\sqrt{149}}{9} = \\boxed{\\frac{2 \\sqrt{149}}{3}}.\\] \nFinal Answer: The final answer is $\\frac{2 \\sqrt{149}}{3}$.',
             "few_shot": "1",
         },
         {
             "problem": "Ryan has 3 red lava lamps and 3 blue lava lamps. He arranges them in a row on a shelf randomly, then turns 3 random lamps on. What is the probability that the leftmost lamp on the shelf is red, and the leftmost lamp which is turned on is also red?",
-            "solution": "There are $\binom{6}{3}=20$ ways for Ryan to arrange the lamps, and $\binom{6}{3}=20$ ways for him to choose which lamps are on, giving $20\cdot20=400$ total possible outcomes. There are two cases for the desired outcomes: either the left lamp is on, or it isn't. If the left lamp is on, there are $\binom{5}{2}=10$ ways to choose which other lamps are on, and $\binom{5}{2}=10$ ways to choose which other lamps are red. This gives $10\cdot10=100$ possibilities. If the first lamp isn't on, there are $\binom{5}{3}=10$ ways to choose which lamps are on, and since both the leftmost lamp and the leftmost lit lamp must be red, there are $\binom{4}{1}=4$ ways to choose which other lamp is red. This case gives 40 valid possibilities, for a total of 140 valid arrangements out of 400. Therefore, the probability is $\dfrac{140}{400}=\boxed{\dfrac{7}{20}}$. \nFinal Answer: The final answer is $\dfrac{7}{20}$.",
+            "solution": "There are $\binom{6}{3}=20$ ways for Ryan to arrange the lamps, and $\binom{6}{3}=20$ ways for him to choose which lamps are on, giving $20\\cdot20=400$ total possible outcomes. There are two cases for the desired outcomes: either the left lamp is on, or it isn't. If the left lamp is on, there are $\binom{5}{2}=10$ ways to choose which other lamps are on, and $\binom{5}{2}=10$ ways to choose which other lamps are red. This gives $10\\cdot10=100$ possibilities. If the first lamp isn't on, there are $\binom{5}{3}=10$ ways to choose which lamps are on, and since both the leftmost lamp and the leftmost lit lamp must be red, there are $\binom{4}{1}=4$ ways to choose which other lamp is red. This case gives 40 valid possibilities, for a total of 140 valid arrangements out of 400. Therefore, the probability is $\\dfrac{140}{400}=\boxed{\\dfrac{7}{20}}$. \nFinal Answer: The final answer is $\\dfrac{7}{20}$.",
             "few_shot": "1",
         },
     ]
 
 
-def process_results(doc: dict, results: List[str]) -> Dict[str, int]:
+def process_results(doc: dict, results: list[str]) -> dict[str, int]:
     candidates = results[0]
 
     unnormalized_answer = get_unnormalized_answer(candidates)
     answer = normalize_final_answer(unnormalized_answer)
 
-    if is_equiv(answer, doc["answer"]):
-        retval = 1
-    else:
-        retval = 0
+    retval = 1 if is_equiv(answer, doc["answer"]) else 0
 
     # math_verify
     res = verify(parse(doc["answer"]), parse(candidates))
@@ -103,7 +101,7 @@ def process_results(doc: dict, results: List[str]) -> Dict[str, int]:
     return results
 
 
-def last_boxed_only_string(string: str) -> Optional[str]:
+def last_boxed_only_string(string: str) -> str | None:
     idx = string.rfind("\\boxed")
     if "\\boxed " in string:
         return "\\boxed " + string.split("\\boxed ")[-1].split("$")[0]
@@ -125,10 +123,7 @@ def last_boxed_only_string(string: str) -> Optional[str]:
                 break
         i += 1
 
-    if right_brace_idx is None:
-        retval = None
-    else:
-        retval = string[idx : right_brace_idx + 1]
+    retval = None if right_brace_idx is None else string[idx : right_brace_idx + 1]
 
     return retval
 
@@ -187,10 +182,7 @@ def is_equiv(x1: str, x2: str) -> bool:
                 return False
 
             try:
-                if sympy.simplify(diff) == 0:
-                    return True
-                else:
-                    return False
+                return sympy.simplify(diff) == 0
             except ValueError:
                 eval_logger.debug(
                     f"Had some trouble simplifying when comparing {x1} and {x2}"

--- a/lm_eval/tasks/minerva_math/utils.py
+++ b/lm_eval/tasks/minerva_math/utils.py
@@ -202,15 +202,27 @@ def is_equiv(x1: str, x2: str) -> bool:
 def get_unnormalized_answer(text: str) -> str:
     INVALID_ANSWER = "[invalidanswer]"
     end_seq = "I hope it is correct."
-    text += end_seq
     match = re.search(
         r"Final Answer: The final answer is(.*?). I hope it is correct.",
-        text,
+        # NB: end_seq is appended with a separating space. Concatenating it directly
+        # produces "...is 7.I hope it is correct.", and the pattern requires ". I hope",
+        # so the patch-up never fired for text ending on a bare period.
+        text + " " + end_seq,
     )
     if match:
         return match.group(1).strip()
-    else:
-        return INVALID_ANSWER
+
+    # Fall back to the model's own \boxed{...} (as used for the gold solution
+    # above): some completions never emit the "I hope it is correct." phrase at
+    # all, so the regex above never matches even when $X$ is correct.
+    boxed = last_boxed_only_string(text)
+    if boxed is not None:
+        try:
+            return remove_boxed(boxed)
+        except (AssertionError, IndexError):
+            pass
+
+    return INVALID_ANSWER
 
 
 SUBSTITUTIONS = [

--- a/lm_eval/tasks/minerva_math/utils.py
+++ b/lm_eval/tasks/minerva_math/utils.py
@@ -2,7 +2,7 @@ import logging
 import re
 import signal
 from importlib.metadata import version
-from typing import Dict, List, Optional
+from importlib.util import find_spec
 
 import datasets
 
@@ -11,11 +11,12 @@ eval_logger = logging.getLogger(__name__)
 
 
 try:
-    import antlr4
     import sympy
     from math_verify import parse, verify
     from sympy.parsing.latex import parse_latex
 
+    if find_spec("antlr4") is None:
+        raise ModuleNotFoundError("No module named 'antlr4'")
     assert version("antlr4-python3-runtime").startswith("4.11")
 except (ModuleNotFoundError, AssertionError) as e:
     raise type(e)(
@@ -77,10 +78,7 @@ def process_results(doc: dict, results: list[str]) -> dict[str, int]:
     unnormalized_answer = get_unnormalized_answer(candidates)
     answer = normalize_final_answer(unnormalized_answer)
 
-    if is_equiv(answer, doc["answer"]):
-        retval = 1
-    else:
-        retval = 0
+    retval = 1 if is_equiv(answer, doc["answer"]) else 0
 
     # math_verify
     _mvres = verify(
@@ -96,7 +94,7 @@ def process_results(doc: dict, results: list[str]) -> dict[str, int]:
     return res
 
 
-def last_boxed_only_string(string: str) -> Optional[str]:
+def last_boxed_only_string(string: str) -> str | None:
     idx = string.rfind("\\boxed")
     if "\\boxed " in string:
         return "\\boxed " + string.split("\\boxed ")[-1].split("$")[0]
@@ -118,10 +116,7 @@ def last_boxed_only_string(string: str) -> Optional[str]:
                 break
         i += 1
 
-    if right_brace_idx is None:
-        retval = None
-    else:
-        retval = string[idx : right_brace_idx + 1]
+    retval = None if right_brace_idx is None else string[idx : right_brace_idx + 1]
 
     return retval
 
@@ -180,10 +175,7 @@ def is_equiv(x1: str, x2: str) -> bool:
                 return False
 
             try:
-                if sympy.simplify(diff) == 0:
-                    return True
-                else:
-                    return False
+                return sympy.simplify(diff) == 0
             except ValueError:
                 eval_logger.debug(
                     f"Had some trouble simplifying when comparing {x1} and {x2}"

--- a/tests/test_math_answer_extraction.py
+++ b/tests/test_math_answer_extraction.py
@@ -1,0 +1,55 @@
+"""Unit tests for MATH answer extraction (hendrycks_math / minerva_math)."""
+
+from __future__ import annotations
+
+import pytest
+
+
+# These task utils raise at import time unless the `[math]` extra is installed
+# (sympy / antlr4-python3-runtime==4.11 / math_verify), so skip rather than error
+# in environments that do not have it.
+pytest.importorskip("sympy")
+pytest.importorskip("antlr4")
+pytest.importorskip("math_verify")
+
+from tests._sysp_utils import load_task_utils  # noqa: E402
+
+
+UTILS = {
+    "hendrycks_math": load_task_utils(
+        "lm_eval/tasks/hendrycks_math/utils.py", module_name="hendrycks_math_utils"
+    ),
+    "minerva_math": load_task_utils(
+        "lm_eval/tasks/minerva_math/utils.py", module_name="minerva_math_utils"
+    ),
+}
+
+INVALID = "[invalidanswer]"
+
+# (completion, expected extraction, id)
+CASES = [
+    # The phrase is present and complete: the original path, which must not change.
+    (
+        "Final Answer: The final answer is $[2,5)$. I hope it is correct.",
+        "$[2,5)$",
+        "phrase-complete",
+    ),
+    # The phrase is present but the trailing "I hope it is correct." is missing. The
+    # function appends it; that only matches if appended with a separating space.
+    ("Final Answer: The final answer is 7.", "7", "phrase-without-suffix"),
+    # No phrase at all -- the few-shot examples end at "...is $X$." so a model
+    # mirroring them never emits it. Fall back to the completion's own \boxed{}.
+    (r"The answer is $\boxed{2}$.", "2", "boxed-only"),
+    (r"So we get $\boxed{10}$.", "10", "boxed-only-2"),
+    (r"first $\boxed{3}$ then later $\boxed{42}$", "42", "boxed-last-wins"),
+    # Neither phrase nor box: must still be reported invalid.
+    ("I could not solve this problem.", INVALID, "no-answer"),
+]
+
+
+@pytest.mark.parametrize("task", sorted(UTILS))
+@pytest.mark.parametrize(
+    "text,expected", [(c[0], c[1]) for c in CASES], ids=[c[2] for c in CASES]
+)
+def test_get_unnormalized_answer(task: str, text: str, expected: str) -> None:
+    assert UTILS[task].get_unnormalized_answer(text) == expected


### PR DESCRIPTION
## Problem

`get_unnormalized_answer()` in `hendrycks_math` and `minerva_math` extracts the model's answer
using a single regex that requires the literal phrase:

```
Final Answer: The final answer is ... . I hope it is correct.
```

and returns `[invalidanswer]` otherwise. Correct answers are discarded since:

### 1. The `end_seq` patch-up is concatenated without a separator

The function already tries to adapt to a missing suffix by appending it:

```python
text += end_seq            # end_seq = "I hope it is correct."
```

For a completion ending on a bare period, this produces `"...is 7.I hope it is correct."`, while the
pattern requires `". I hope"` - with a space. 

### 2. The phrase may be absent entirely

The hardcoded few-shot examples in `list_fewshot_samples()` end each solution right after
`"Final Answer: The final answer is $X$."` with no `"I hope it is correct."` suffix. A model
that mirrors that in-context style never produces the phrase either, so there is nothing for the
regex to match, even when `$X$` is right.

## Fix

1. Append `end_seq` with a separating space, so the existing patch-up works as intended.
2. When the phrase is absent, fall back to the completion's own `\boxed{...}` using the file's
   existing `last_boxed_only_string()` / `remove_boxed()` helpers - already used in the same file
   to parse the gold answer - before returning `[invalidanswer]`.

Both changes only *add* extractions. The existing phrase-match path is untouched, and a completion
with neither a phrase nor a box still yields `[invalidanswer]`.

## Testing

Six cases per file:

| case | expected | before | after |
|---|---|---|---|
| `The answer is $\boxed{2}$.` (captured sample, gold 2) | `2` | `[invalidanswer]` | `2` |
| `So we get $\boxed{10}$.` (captured sample, gold 10) | `10` | `[invalidanswer]` | `10` |
| `Final Answer: The final answer is $[2,5)$. I hope it is correct.` | `$[2,5)$` | `$[2,5)$` | `$[2,5)$` (non-regression) |
| `Final Answer: The final answer is 7.` | `7` | `[invalidanswer]` | `7` |
| `I could not solve this problem.` | `[invalidanswer]` | `[invalidanswer]` | `[invalidanswer]` (true negative) |
| `first $\boxed{3}$ then later $\boxed{42}$` | `42` | `[invalidanswer]` | `42` |

## Note regarding `lm_eval/tasks/leaderboard/math/utils.py`

That file has the same defect, yet tasks under `lm_eval/tasks/leaderboard/` exist to reproduce the Open LLM
Leaderboard's published scoring, and a more accurate parser would change numbers that are meant
to stay comparable to already published results.  

I can add it here or open a separate PR - please let me know.