### PR TITLE
docs: document three ways a run can exit 0 without a valid result

### DIFF
--- a/docs/footguns.md
+++ b/docs/footguns.md
@@ -56,3 +56,48 @@ generation_kwargs:
   unicode: "Copyright symbol: \u00A9"  # Unicode character
 
   ```
+
+## Evaluation Result Validity
+
+A run can exit 0 and still write a number that is not a measurement. These are three ways we
+hit that in practice, all on this fork; none of them raise an error, so they are easy to carry into a results table.
+
+### An unreachable judge model uses the full walltime before writing NaN
+
+**Problem:** LLM-judge-backed tasks (e.g. `harmbench`) call
+out to a separately-served judge model. If that judge is not actually being served, every call
+fails, each sample is retried several times, and the task still "completes" - with
+`{"score": np.nan}` for every sample and a NaN aggregate. Neither the exit code nor the log volume distinguishes this from a real run; the only tell is the aggregate itself, at walltime end (the retry loop, not generation, is what exhausted it).
+
+**What to check:** before relying on any judge-backed task, confirm the judge is actually being
+served under the name the task expects - a stale or renamed serving endpoint produces exactly
+this symptom, not a connection error. If a task's aggregate is NaN, treat it as "did not run",
+not as a score.
+
+### An all-NaN aggregate is written like any other result
+
+**Problem:** related to the above but distinct - even where a judge is reachable, it can return
+values the metric can't use (observed on a toxicity-judge task: every sample scored NaN with the
+judge responding normally, not erroring). In both cases the aggregate lands in the results JSON
+indistinguishable in shape from a valid score; nothing marks the task as failed.
+
+**What to check:** treat an all-NaN aggregate as a failed task rather than a low score when
+post-processing results, particularly before feeding a results table into any further comparison
+or averaging - an unnoticed NaN can silently drop out of an average in a way a real low score
+would not.
+
+### `--apply_chat_template` on a `loglikelihood` task changes what is being measured
+
+**Problem:** `loglikelihood` tasks like `lambada` or `squadv2` work by measuring how much
+probability the model assigns to a natural continuation of a text fragment. Under
+`--apply_chat_template`, that fragment is wrapped as a user turn, and the target text is then
+scored as if it were the start of an assistant reply - a different, and generally much less
+likely, continuation. Measured on one base model: `lambada` accuracy went from 0.72 (perplexity
+3.78) to exactly 0.0 (perplexity 8569); `squadv2` F1 from 32.1 to 10.4. The only signal is a log
+line at eval start - *"Chat template formatting change affects loglikelihood and multiple-choice
+tasks."* - easy to miss in a large task list, and nothing prevents the run from completing and
+reporting the degenerate score as final.
+
+**What to check:** if you are applying a chat template, check whether every task in your list is
+actually meant to be read that way. This is not specific to any one task set - it applies to any
+`loglikelihood`-type task run with `--apply_chat_template` on.


### PR DESCRIPTION
Documentation only, no functional change. This adds an "Evaluation Result Validity" section to
`docs/footguns.md` covering three ways a run completed exit-0 without producing a valid result,
none of which raise an error or show up in the exit code.

I'm opening this as a PR rather than an issue because there's no Issues (or Discussions) tab on the repository.

## The three items are as follows:

1. **A judge-backed task whose judge isn't actually being served retries every sample to
   exhaustion, then writes a NaN aggregate.** Hit this on `harmbench` - the judge wasn't served on our endpoint, every call failed, each sample retried several times, and the task "completed" with a NaN aggregate after consuming its full walltime in retries rather than generation.

2. **An all-NaN aggregate is written indistinguishably from a valid score**, even when the judge is reachable - observed separately on a toxicity-judge task, every sample scored NaN with the judge responding normally (not erroring).

3. **`--apply_chat_template` on a `loglikelihood` task silently changes what's being measured.**   `lambada`/`squadv2`-style tasks score how likely a fragment's natural continuation is; under a chat template the fragment becomes a user turn and the target is scored as an assistant reply - a different, much less likely, continuation. Measured on one base model: `lambada`  accuracy 0.72 -> 0.0 (perplexity 3.78 -> 8569), `squadv2` F1 32.1 -> 10.4. The only signal is one log line at eval start, easy to miss in a large task list.

## Scope note

Items 1 and 2 are specific to judge-backed tasks that aren't part of upstream `EleutherAI/lm-evaluation-harness` (`harmbench`, the toxicity-judge tasks, and similar aren't in their tree - checked before writing this up). Item 3 is core harness behavior (`apply_chat_template` x `loglikelihood` `output_type`) and applies to any task list using this combination, not something specific to any task set here.

## Testing

N/A.
