### PR TITLE
hallulens: make judge model + tokenizer configurable

### DIFF
--- a/lm_eval/tasks/hallulens/metrics.py
+++ b/lm_eval/tasks/hallulens/metrics.py
@@ -16,7 +16,9 @@ if _METRICS_CACHE_KEY not in sys.modules:
     # Verify remote API connection
     _test = try_remote_generate("hello there")
 
-    _tokenizer = AutoTokenizer.from_pretrained("Qwen/Qwen3.5-27B")
+    _tokenizer = AutoTokenizer.from_pretrained(
+        os.getenv("HALLULENS_JUDGE_TOKENIZER", "Qwen/Qwen3.5-27B")
+    )
     if _test is None:
         raise RuntimeError("Remote generation failed, cannot connect to the model API. Please check your connection and API key.")
     else:

--- a/lm_eval/tasks/hallulens/utils.py
+++ b/lm_eval/tasks/hallulens/utils.py
@@ -11,7 +11,7 @@ import aiohttp
 
 API_URL = "https://api.swissai.svc.cscs.ch/v1"
 API_KEY = os.getenv("CSCS_SERVING_API")
-MODEL_NAME = "Qwen/Qwen3.5-27B"
+MODEL_NAME = os.getenv("HALLULENS_JUDGE_MODEL", "Qwen/Qwen3.5-27B")
 
 def try_remote_generate(prompt, temperature=0.0, max_tokens=512, max_retries=20):
     """


### PR DESCRIPTION
The hallulens judge is hardcoded to `Qwen/Qwen3.5-27B` in `utils.py` (`MODEL_NAME`) and `metrics.py` (tokenizer). It cannot be swapped for another judge, and it does not resolve when the judge is served under a namespaced id (e.g. behind a serving gateway).

Read both from env vars (`HALLULENS_JUDGE_MODEL`, `HALLULENS_JUDGE_TOKENIZER`), keeping the current value as the default (backward-compatible).