### PR TITLE
Upgrade to Python 3.11

### DIFF
--- a/lm_eval/__init__.py
+++ b/lm_eval/__init__.py
@@ -4,7 +4,14 @@ import os
 from importlib.util import find_spec
 
 
-__version__ = importlib.metadata.version("lm_eval")
+try:
+    __version__ = importlib.metadata.version("lm_eval")
+except importlib.metadata.PackageNotFoundError:
+    # Allow the vendored checkout to run directly from PYTHONPATH without an
+    # installed lm_eval distribution. The launcher in this repo points at
+    # third_party/lm-evaluation-harness, so local imports should work even when
+    # package metadata is absent.
+    __version__ = "0.0.0+local"
 
 
 # Enable high-performance transfers

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,7 @@ classifiers = [
     "Programming Language :: Python :: 3",
     "Operating System :: OS Independent",
 ]
-requires-python = ">=3.10"
+requires-python = ">=3.11"
 license = { text = "MIT" }
 dependencies = [
     "datasets==4.0.0",


### PR DESCRIPTION
Currently running `uv sync` on this repo (locally or on cluster, both with Python 3.12) produces a dependency conflict:

```
$ uv sync
  × No solution found when resolving dependencies for split (markers: python_full_version == '3.10.*'; included: lm-eval[math], lm-eval[vllm];     
  │ excluded: lm-eval[acpbench], lm-eval[gptq]):
  ╰─▶ Because the requested Python version (>=3.10) does not satisfy Python>=3.11 and all versions of subset2evaluate depend on Python>=3.11, we   
      can conclude that all versions of subset2evaluate cannot be used.
      And because lm-eval[tasks] depends on subset2evaluate and your project requires lm-eval[tasks], we can conclude that your project's
      requirements are unsatisfiable.

hint: While the active Python version is 3.12, the resolution failed for other Python versions supported by your project. Consider limiting your project's supported Python versions using `requires-python`.
hint: The `requires-python` value (>=3.10) includes Python versions that are not supported by your dependencies (e.g., all versions of subset2evaluate only supports >=3.11). Consider using a more restrictive `requires-python` value (like >=3.11).
```

I checked all our other open PRs. The only one that touches [pyproject.toml](https://github.com/ymetz/lm-evaluation-harness/blob/78f3e933653ace3ad2721b2c95cc6b63cefaabf6/pyproject.toml) is #75 

I've tested that this works within my setup, but the change may affect other parts of the code. I am surprised that this does not seem to be affecting the upstream version, which is still on Python 3.10 like ours, and I don't see any open issues about this.